### PR TITLE
Fix soundness hole in GC finalisers

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -263,6 +263,7 @@ symbols! {
         Rc,
         Ready,
         Receiver,
+        ReferenceFree,
         Relaxed,
         Release,
         Result,

--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -61,6 +61,9 @@ use core::sync::atomic::{self, AtomicU64};
 
 use core::gc::NoTrace;
 
+#[cfg(not(no_global_oom_handling))]
+use core::gc::ReferenceFree;
+
 use boehm::GcAllocator;
 
 #[cfg(test)]
@@ -411,7 +414,7 @@ impl<T> GcBox<MaybeUninit<T>> {
 
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "gc", issue = "none")]
-impl<T: Default + Send + Sync> Default for Gc<T> {
+impl<T: Default + Send + Sync + ReferenceFree> Default for Gc<T> {
     /// Creates a new `Gc<T>`, with the `Default` value for `T`.
     ///
     /// # Examples

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -103,3 +103,10 @@ impl<T: ?Sized> DerefMut for NonFinalizable<T> {
         &mut self.0
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "ReferenceFree")]
+pub auto trait ReferenceFree {}
+
+impl<T> !ReferenceFree for &T {}
+impl<T> !ReferenceFree for &mut T {}

--- a/src/test/rustdoc/empty-section.rs
+++ b/src/test/rustdoc/empty-section.rs
@@ -13,3 +13,4 @@ impl !std::marker::Unpin for Foo {}
 impl !std::panic::RefUnwindSafe for Foo {}
 impl !std::panic::UnwindSafe for Foo {}
 impl !std::gc::NoTrace for Foo {}
+impl std::gc::ReferenceFree for Foo {}

--- a/src/test/rustdoc/issue-50159.rs
+++ b/src/test/rustdoc/issue-50159.rs
@@ -15,7 +15,7 @@ impl<B, C> Signal2 for B where B: Signal<Item = C> {
 // @has - '//h3[@class="code-header in-band"]' 'impl<B> Sync for Switch<B> where <B as Signal>::Item: Sync'
 // @has - '//h3[@class="code-header in-band"]' 'impl<B> FinalizerSafe for Switch<B> where <B as Signal>::Item: FinalizerSafe'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 7
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 8
 pub struct Switch<B: Signal> {
     pub inner: <B as Signal2>::Item2,
 }

--- a/src/test/rustdoc/synthetic_auto/basic.rs
+++ b/src/test/rustdoc/synthetic_auto/basic.rs
@@ -3,7 +3,7 @@
 // @has - '//h3[@class="code-header in-band"]' 'impl<T> Sync for Foo<T> where T: Sync'
 // @has - '//h3[@class="code-header in-band"]' 'impl<T> FinalizerSafe for Foo<T> where T: FinalizerSafe'
 // @count - '//*[@id="implementations-list"]//*[@class="impl has-srclink"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 7
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 8
 pub struct Foo<T> {
     field: T,
 }

--- a/src/test/ui/gc/check_finalizers.rs
+++ b/src/test/ui/gc/check_finalizers.rs
@@ -75,6 +75,7 @@ fn main() {
 
     let boxed_trait: Box<dyn Opaque> = Box::new(ShouldPass(123 as *mut u8));
     Gc::new(boxed_trait); //~ ERROR: `boxed_trait` cannot be safely finalized.
+                          //~^ ERROR: `boxed_trait` cannot be safely constructed.
 
     let gcfields = HasGcFields(Gc::new(123));
     Gc::new(gcfields); //~ ERROR: `gcfields` cannot be safely finalized.

--- a/src/test/ui/gc/check_finalizers.stderr
+++ b/src/test/ui/gc/check_finalizers.stderr
@@ -13,6 +13,15 @@ LL |     Gc::new(ShouldFail(Cell::new(123)));
    = help: `Gc` runs finalizers on a separate thread, so drop methods
            must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
 
+error: `boxed_trait` cannot be safely constructed.
+  --> $DIR/check_finalizers.rs:77:13
+   |
+LL |     Gc::new(boxed_trait);
+   |     --------^^^^^^^^^^^-
+   |     |       |
+   |     |       contains a reference (&) which may no longer be valid when it is finalized.
+   |     `Gc::new` requires that a type is reference free.
+
 error: `boxed_trait` cannot be safely finalized.
   --> $DIR/check_finalizers.rs:77:13
    |
@@ -25,7 +34,7 @@ LL |     Gc::new(boxed_trait);
    = help: `Gc` runs finalizers on a separate thread, so `boxed_trait` must implement `FinalizeSafe` in order to be safely dropped.
 
 error: `gcfields` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:80:13
+  --> $DIR/check_finalizers.rs:81:13
    |
 LL |         println!("Boom {}", self.0);
    |                             ------
@@ -39,7 +48,7 @@ LL |     Gc::new(gcfields);
    = help: `Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.
 
 error: `self_call` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:83:13
+  --> $DIR/check_finalizers.rs:84:13
    |
 LL |         self.foo();
    |         ----------
@@ -54,7 +63,7 @@ LL |     Gc::new(self_call);
            must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
 
 error: `transparent_call` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:86:13
+  --> $DIR/check_finalizers.rs:87:13
    |
 LL |         let x = ShouldPassInFuture(456 as *mut u8);
    |                 ----------------------------------
@@ -68,5 +77,5 @@ LL |     Gc::new(transparent_call);
    = help: `Gc` runs finalizers on a separate thread, so drop methods
            must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
A potential soundness hole exists in GC finalisers when `Gc<T>`s that contain ordinary Rust references (`&`/`&mut`) are used with finalisers.

Consider the following:

```rust
fn main() {
    let b = Box::new(123);
    let gc: Gc<&usize> = Gc::new(b.as_ref());

    // foo(b);
    // dbg(gc); // ERROR: use-after-move
}
```

This kind of program might seem weird, but it is perfectly safe. The lifetime of `gc` is tied to `b`. The compiler catches uses of `gc` after a move of `b` as we'd expect.

If we introduce finalisers into the mix, this can become unsound. It seems like ownership should save us here, after all, `gc` cannot outlive `b`. However, finalisers provide a stealthy way to violate soundness because they can run at the collector's leisure - potentially long after `b` has been dropped. Let's extend the above example to make this more concrete:

```rust

struct Wrapper<'a>(&'a usize);

impl<'a> Drop for Wrapper<'a> {
    fn drop(&mut self) {
        println!("Dropping {}", self.0);
    }
}

fn main() {

    {
        let b = Box::new(123);
        let gc = Gc::new(Wrapper(b.as_ref()));
    } // b is dropped

    // GC happens here, calling `Wrapper::drop` as a finaliser.
    // BOOM! use-after-free.
}
```

The above can cause a use-after-free if the finaliser for `Wrapper` (which derefs the `&usize` field) is run after `b`'s `Box` is already droppped.

Fortunately there is a solution to this. It's possible by imposing a rule on `Gc<T>`s:

    A type `T` must never be placed in a `Gc<T>` if the both of the following
    statements are true for `T`:

        1. `T` (or any component type of `T`) contains any field of type `&U` or
        `&mut U`.

        2. `T` requires a finaliser.

This rule is fairly easy to enforce with a slight modification to our existing finaliser checks. We first introduce a new auto trait `ReferenceFree`, which is unimplemented on reference types:

```rust
impl !ReferenceFree for &T {}
impl !ReferenceFree for &mut T {}
```

Then, at every `Gc<T>::new` callsite, the compiler will check whether `T` adheres to the new rule. If it doesn't, we throw a compiler error. The following shows the compiler error for the second example above:

```
error: `Wrapper(b.as_ref())` cannot be safely constructed.
  --> src/main.rs:19:26
   |
19 |         let gc = Gc::new(Wrapper(b.as_ref()));
   |                  --------^^^^^^^^^^^^^^^^^^^-
   |                  |       |
   |                  |       contains a reference (&) which may no longer be valid when it is finalized.
   |                  `Gc::new` requires that a type is reference free.

warning: `ref_soundness` (bin "ref_soundness") generated 1 warning
error: could not compile `ref_soundness` due to previous error; 1 warning emitted
```

The drawback of this approach is that it can be overly restrictive. This will disallow `T`s with reference fields which are never actually used inside `T::drop`. I believe a more advanced version of drop MIR checking could account for this, but it's tricky. We would need a way to differentiate between perfectly safe references like `&mut self`, and unsafe references to other objects. This is not easy in MIR with its current limited form of def-use analysis.

Instead, I feel the current approach is adequate. If a user _really_ wants to use `T` with reference fields in a `Gc` and they are certain that it is not being used in `T::drop` in an unsound way, then they can always unsafe impl `ReferenceFree` for `T`, and `Gc<T>` would pass the analysis.