### PR TITLE
Remove gc drops before adding call guard edges

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -574,12 +574,13 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &multiple_return_terminators::MultipleReturnTerminators,
             &deduplicate_blocks::DeduplicateBlocks,
             &large_enums::EnumSizeOpt { discrepancy: 128 },
+            // Must come before CriticalCallEdges to prevent LLVM basic block ordering errors.
+            &remove_gc_drops::RemoveGcDrops,
             // Some cleanup necessary at least for LLVM and potentially other codegen backends.
             &add_call_guards::CriticalCallEdges,
             // Cleanup for human readability, off by default.
             &prettify::ReorderBasicBlocks,
             &prettify::ReorderLocals,
-            &remove_gc_drops::RemoveGcDrops,
             // Dump the end result for testing and debugging purposes.
             &dump_mir::Marker("PreCodegen"),
         ],

--- a/tests/ui/runtime/gc/early_finalization.rs
+++ b/tests/ui/runtime/gc/early_finalization.rs
@@ -1,0 +1,22 @@
+// run-fail
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+
+use std::gc::Gc;
+use std::ffi::{CString, NulError};
+use std::io::{self, Write};
+
+fn fallible() -> Result<(), NulError> {
+    let e: NulError = CString::new(b"f\0oo".to_vec()).unwrap_err();
+    Err(e)
+}
+
+fn main() -> io::Result<()> {
+    let mut _stdout = io::stdout().lock();
+    fallible()?;
+    let gc = Gc::new(123);
+    fallible()?;
+    Ok(())
+}


### PR DESCRIPTION
The CriticalCallEdges requries that the CFG has been simplified to its final stage so removing terminators afterwards breaks the LLVM IR.