### PR TITLE
Add wrapper type for opting out of FSA

### DIFF
--- a/tests/ui/runtime/gc/check_finalizers.rs
+++ b/tests/ui/runtime/gc/check_finalizers.rs
@@ -2,7 +2,7 @@
 #![feature(negative_impls)]
 
 use std::cell::Cell;
-use std::gc::Gc;
+use std::gc::{Gc, FinalizeUnchecked};
 use std::marker::FinalizerSafe;
 use std::rc::Rc;
 
@@ -61,4 +61,6 @@ fn main() {
 
     let self_call = ShouldFail2(123 as *mut u8);
     Gc::new(self_call); //~ ERROR: `self_call` cannot be safely finalized.
+
+    unsafe { Gc::new(FinalizeUnchecked::new(ShouldFail(Cell::new(123)))) };
 }

--- a/tests/ui/runtime/gc/unchecked_finalizer.rs
+++ b/tests/ui/runtime/gc/unchecked_finalizer.rs
@@ -1,0 +1,38 @@
+// run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![feature(rustc_private)]
+#![feature(negative_impls)]
+
+use std::gc::{Gc, GcAllocator, FinalizeUnchecked};
+use std::sync::atomic::{self, AtomicUsize};
+
+struct UnsafeContainer(usize);
+
+impl Drop for UnsafeContainer {
+    fn drop(&mut self) {
+        FINALIZER_COUNT.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+}
+
+impl !FinalizerSafe for UnsafeContainer {}
+
+static FINALIZER_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_COUNT: usize = 100;
+
+fn foo() {
+    for i in 0..ALLOCATED_COUNT {
+        {
+            let mut _gc = unsafe { Some(Gc::new(FinalizeUnchecked::new(UnsafeContainer(i)))) };
+
+            // Zero the root to the GC object.
+            _gc = None;
+        }
+    }
+}
+
+fn main() {
+    foo();
+    GcAllocator::force_gc();
+    assert_eq!(FINALIZER_COUNT.load(atomic::Ordering::Relaxed), ALLOCATED_COUNT);
+}


### PR DESCRIPTION
This can be very useful when using types from third party crates which do not implement `FinalizerSafe`. Instead of implementing `FinalizerSafe` on any `T` with a `!FinalizerSafe` field, we can now ensure each problematic field uses the `FinalizeUnchecked<U>` wrapper. This is safer than a blanket implementation.