### PR TITLE
Fix incorrect finalizer registration

### DIFF
--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -280,7 +280,7 @@ impl<T> Gc<T> {
 
         unsafe {
             ALLOCATOR.register_finalizer(
-                self as *mut _ as *mut u8,
+                self.ptr.as_ptr() as *mut u8,
                 Some(finalizer::<T>),
                 null_mut(),
                 null_mut(),

--- a/tests/ui/runtime/gc/run_finalizers.rs
+++ b/tests/ui/runtime/gc/run_finalizers.rs
@@ -1,0 +1,35 @@
+// run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![feature(rustc_private)]
+
+use std::gc::{Gc, GcAllocator};
+use std::sync::atomic::{self, AtomicUsize};
+
+struct Finalizable(usize);
+
+impl Drop for Finalizable {
+    fn drop(&mut self) {
+        FINALIZER_COUNT.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+}
+
+static FINALIZER_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_COUNT: usize = 100;
+
+fn foo() {
+    for i in 0..ALLOCATED_COUNT {
+        {
+            let mut _gc = Some(Gc::new(Finalizable(i)));
+
+            // Zero the root to the GC object.
+            _gc = None;
+        }
+    }
+}
+
+fn main() {
+    foo();
+    GcAllocator::force_gc();
+    assert_eq!(FINALIZER_COUNT.load(atomic::Ordering::Relaxed), ALLOCATED_COUNT);
+}


### PR DESCRIPTION
This fixes a bug in finalizer registration in Alloy were the wrong pointer was being passed to Boehm. A pointer to underlying `GcBox` should be passed instead of the `Gc` smart pointer.