### PR TITLE
Change FSA to check for `Send + Sync` explicitly

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -80,7 +80,15 @@ impl<'tcx> FinalizationCtxt<'tcx> {
     }
 
     fn check(&mut self, ty: Ty<'tcx>) {
-        if self.is_finalizer_safe(ty) || !self.tcx.needs_finalizer_raw(self.param_env.and(ty)) {
+        if !self.tcx.needs_finalizer_raw(self.param_env.and(ty)) {
+            return;
+        }
+
+        if self.is_finalize_unchecked(ty) {
+            return;
+        }
+
+        if self.is_send(ty) && self.is_sync(ty) && self.is_finalizer_safe(ty) {
             return;
         }
 
@@ -176,9 +184,38 @@ impl<'tcx> FinalizationCtxt<'tcx> {
         ty.is_copy_modulo_regions(self.tcx, self.param_env)
     }
 
+    fn is_send(&self, ty: Ty<'tcx>) -> bool {
+        let t = self.tcx.get_diagnostic_item(sym::Send).unwrap();
+        return self
+            .tcx
+            .infer_ctxt()
+            .build()
+            .type_implements_trait(t, [ty], self.param_env)
+            .must_apply_modulo_regions();
+    }
+
+    fn is_sync(&self, ty: Ty<'tcx>) -> bool {
+        let t = self.tcx.get_diagnostic_item(sym::Sync).unwrap();
+        return self
+            .tcx
+            .infer_ctxt()
+            .build()
+            .type_implements_trait(t, [ty], self.param_env)
+            .must_apply_modulo_regions();
+    }
+
     fn is_gc(&self, ty: Ty<'tcx>) -> bool {
         if let ty::Adt(def, ..) = ty.kind() {
             if def.did() == self.tcx.get_diagnostic_item(sym::gc).unwrap() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn is_finalize_unchecked(&self, ty: Ty<'tcx>) -> bool {
+        if let ty::Adt(def, ..) = ty.kind() {
+            if def.did() == self.tcx.get_diagnostic_item(sym::FinalizeUnchecked).unwrap() {
                 return true;
             }
         }
@@ -223,7 +260,7 @@ impl<'a, 'tcx> ProjectionChecker<'a, 'tcx> {
             err.span_label(self.cx.arg, "has a drop method which cannot be safely finalized.");
             err.span_label(span, "caused by the expression in `fn drop(&mut)` here because");
             err.span_label(span, "it uses a type which is not safe to use in a finalizer.");
-            err.help("`Gc` runs finalizers on a separate thread, so drop methods\nmust only use values whose types implement `Send + Sync` or `FinalizerSafe`.");
+            err.help("`Gc` runs finalizers on a separate thread, so drop methods\nmust only use values whose types implement `Send + Sync + FinalizerSafe`.");
         }
         err.emit();
     }
@@ -239,7 +276,10 @@ impl<'a, 'tcx> Visitor<'tcx> for ProjectionChecker<'a, 'tcx> {
         for (_, proj) in place_ref.iter_projections() {
             match proj {
                 ProjectionElem::Field(_, ty) => {
-                    if !self.cx.is_finalizer_safe(ty) {
+                    if !self.cx.is_finalizer_safe(ty)
+                        || !self.cx.is_send(ty)
+                        || !self.cx.is_sync(ty)
+                    {
                         let span = self.body.source_info(location).span;
                         self.emit_err(ty, span);
                     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -189,6 +189,7 @@ symbols! {
         Error,
         File,
         FileType,
+        FinalizeUnchecked,
         FinalizerSafe,
         FormatSpec,
         Formatter,

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -60,6 +60,7 @@ impl<T: ?Sized> DerefMut for NonFinalizable<T> {
 /// implementing the `FinalizerSafe` trait for `T` as `FinalizeUnchecked`
 /// applies only to individual uses of `T`.
 #[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "FinalizeUnchecked")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FinalizeUnchecked<T: ?Sized>(T);
 

--- a/tests/ui/runtime/gc/check_finalizers.stderr
+++ b/tests/ui/runtime/gc/check_finalizers.stderr
@@ -1,5 +1,5 @@
 error: `ShouldFail(Cell::new(123))` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:57:13
+  --> $DIR/check_finalizers.rs:71:13
    |
 LL |         self.0.replace(456);
    |         ------
@@ -11,10 +11,10 @@ LL |     Gc::new(ShouldFail(Cell::new(123)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
+           must only use values whose types implement `Send + Sync + FinalizerSafe`.
 
 error: `gcfields` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:60:13
+  --> $DIR/check_finalizers.rs:74:13
    |
 LL |         println!("Boom {}", self.0);
    |                             ------
@@ -28,7 +28,7 @@ LL |     Gc::new(gcfields);
    = help: `Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.
 
 error: `self_call` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:63:13
+  --> $DIR/check_finalizers.rs:77:13
    |
 LL |         self.foo();
    |         ----------
@@ -40,7 +40,22 @@ LL |     Gc::new(self_call);
    |             ^^^^^^^^^ has a drop method which cannot be safely finalized.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
+           must only use values whose types implement `Send + Sync + FinalizerSafe`.
 
-error: aborting due to 3 previous errors
+error: `not_threadsafe` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:80:13
+   |
+LL |         println!("Boom {}", self.0.0);
+   |                             --------
+   |                             |
+   |                             caused by the expression in `fn drop(&mut)` here because
+   |                             it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(not_threadsafe);
+   |             ^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `Send + Sync + FinalizerSafe`.
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Previously FSA only checked that drop methods dereferenced `FinalizerSafe` fields. The benefit of this is that it allows a greater number of finalisers to pass because `FinalizerSafe` is concerned with type safety in the context of GC only.

However, as an auto trait, `FinalizerSafe` is automatically implemented on types in third party crates which have no knowledge of Alloy. This could mean that non-Send + non-Sync types are erroneously marked as safe to finalise. In the interest of soundness, we err on the side of caution and modify FSA to check for the existence of `FinalizerSafe + Send + Sync`.