### PR TITLE
Always build Boehm in release mode

### DIFF
--- a/library/boehm/build.rs
+++ b/library/boehm/build.rs
@@ -36,6 +36,7 @@ fn main() {
 
     cmake::Config::new(&boehm_src)
         .pic(true)
+        .profile("Release")
         .define("BUILD_SHARED_LIBS", "OFF")
         .cflag("-DGC_ALWAYS_MULTITHREADED")
         .cflag("-DGC_JAVA_FINALIZATION")


### PR DESCRIPTION
If you build Alloy with debuginfo in order to debug the compiler, this will build the BDWGC runtime in debug mode too. As the BDWGC is linked into target programs, it will end up using a debug build regardless of the user's cargo flags, this is rarely what we want.