### PR TITLE
Make `FinalizerUnchecked` inner field public

### DIFF
--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -62,7 +62,7 @@ impl<T: ?Sized> DerefMut for NonFinalizable<T> {
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "FinalizeUnchecked")]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct FinalizeUnchecked<T: ?Sized>(T);
+pub struct FinalizeUnchecked<T: ?Sized>(pub T);
 
 impl<T> FinalizeUnchecked<T> {
     pub unsafe fn new(value: T) -> Self {


### PR DESCRIPTION
This wrapper struct has no runtime semantics (it exists only for a type to opt out of FSA) so there is no need to restrict access to its contents.