### PR TITLE
Do not suppress all Boehm warnings

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -103,10 +103,6 @@ unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         // handler next time. The is not true in the reverse case.
         alloc::gc::init();
 
-        // Boehm GC prints OOM warnings which are useful for debugging, but
-        // annoying when building the compiler in release mode.
-        alloc::gc::suppress_warnings();
-
         sys::init(argc, argv, sigpipe);
 
         let main_guard = sys::thread::guard::init();


### PR DESCRIPTION
If something goes wrong during a GC, we likely want to know what happened.

It's not totally clear whether this is the correct way to disable warnings anyway (it uses some deprecated library features in Boehm). Annoying warnings (such as those for many large page allocations) can be disabled individually.