### PR TITLE
Fix thread-locals to be visible by Boehm

### DIFF
--- a/library/std/src/sys/common/thread_local/mod.rs
+++ b/library/std/src/sys/common/thread_local/mod.rs
@@ -11,11 +11,6 @@ cfg_if::cfg_if! {
         mod static_local;
         #[doc(hidden)]
         pub use static_local::{Key, thread_local_inner};
-    } else if #[cfg(target_thread_local)] {
-        #[doc(hidden)]
-        mod fast_local;
-        #[doc(hidden)]
-        pub use fast_local::{Key, thread_local_inner};
     } else {
         #[doc(hidden)]
         mod os_local;

--- a/library/std/src/sys/unix/thread_local_dtor.rs
+++ b/library/std/src/sys/unix/thread_local_dtor.rs
@@ -12,6 +12,7 @@
 // compiling from a newer linux to an older linux, so we also have a
 // fallback implementation to use as well.
 #[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "redox", target_os = "hurd"))]
+#[allow(dead_code)]
 pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     use crate::mem;
     use crate::sys_common::thread_local_dtor::register_dtor_fallback;

--- a/library/std/src/sys_common/thread_local_key.rs
+++ b/library/std/src/sys_common/thread_local_key.rs
@@ -123,6 +123,7 @@ impl StaticKey {
     /// been allocated.
     #[inline]
     pub unsafe fn set(&self, val: *mut u8) {
+        crate::gc::TLS_ROOTSET.push(val as *mut u8);
         imp::set(self.key(), val)
     }
 

--- a/tests/ui/runtime/gc/thread_local.rs
+++ b/tests/ui/runtime/gc/thread_local.rs
@@ -1,0 +1,70 @@
+// run-pass
+// ignore-tidy-linelength
+#![feature(allocator_api)]
+#![feature(gc)]
+#![feature(negative_impls)]
+#![feature(thread_local)]
+
+use std::gc::{Gc, GcAllocator};
+use std::{thread, time};
+use std::sync::atomic::{self, AtomicUsize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Finalizable(u32);
+
+static FINALIZER_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+impl Drop for Finalizable {
+    fn drop(&mut self) {
+        FINALIZER_COUNT.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+}
+
+thread_local!{
+    static LOCAL1: Gc<Finalizable> = Gc::new(Finalizable(1));
+    static LOCAL2: Gc<Finalizable> = Gc::new(Finalizable(2));
+    static LOCAL3: Gc<Finalizable> = Gc::new(Finalizable(3));
+
+    static LOCAL4: Box<Gc<Finalizable>, GcAllocator> = Box::new_in(Gc::new(Finalizable(4)), GcAllocator);
+    static LOCAL5: Box<Gc<Finalizable>, GcAllocator> = Box::new_in(Gc::new(Finalizable(5)), GcAllocator);
+    static LOCAL6: Box<Gc<Finalizable>, GcAllocator> = Box::new_in(Gc::new(Finalizable(6)), GcAllocator);
+}
+
+fn do_stuff_with_tls() {
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().subsec_nanos();
+
+    // We need to use the thread-local at least once to ensure that it is initialised. By adding it
+    // to the current system time, we ensure that this use can't be optimised away (e.g. by constant
+    // folding).
+    let mut dynamic_value = nanos;
+
+    dynamic_value += LOCAL1.with(|l| l.0);
+    dynamic_value += LOCAL2.with(|l| l.0);
+    dynamic_value += LOCAL3.with(|l| l.0);
+    dynamic_value += LOCAL4.with(|l| l.0);
+    dynamic_value += LOCAL5.with(|l| l.0);
+    dynamic_value += LOCAL6.with(|l| l.0);
+
+    // Keep the thread alive long enough so that the GC has the chance to scan its thread-locals for
+    // roots.
+    thread::sleep(time::Duration::from_millis(20));
+
+
+    assert!(dynamic_value > 0);
+
+    // This ensures that a GC invoked from the main thread does not cause this thread's thread
+    // locals to be reclaimed too early.
+    assert_eq!(FINALIZER_COUNT.load(atomic::Ordering::Relaxed), 0);
+
+}
+
+fn main() {
+    let t2 = std::thread::spawn(do_stuff_with_tls);
+
+    // Wait a little bit of time for the t2 to initialise thread-locals.
+    thread::sleep(time::Duration::from_millis(10));
+
+    GcAllocator::force_gc();
+
+    let _ = t2.join().unwrap();
+}


### PR DESCRIPTION
Previously, thread-locals are invisible to Boehm. In other words, a pointer to a heap object stored solely inside a thread-local would cause the GC to free the object too early.

In order to do this, we must disable compiler-based thread local implementation. This is a shame because it's faster than the POSIX thread library impl but it places thread locals in a table in a segment in the binary which Boehm can't scan. It might be possible to fix this in the future, but for now we fallback to using the POSIX thread implementation because there exists a fix for this.

We introduce a global thread-local rootset, which holds pointers to thread-local values which Boehm can scan and use.