### PR TITLE
Allow BDWGC to be linked dynamically

### DIFF
--- a/library/bdwgc/build.rs
+++ b/library/bdwgc/build.rs
@@ -10,6 +10,11 @@ const BDWGC_BUILD_DIR: &str = "lib";
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
 fn main() {
+    if env::var("GC_LINK_DYNAMIC").map_or(false, |v| v == "true") {
+        println!("cargo:rustc-link-lib=dylib=gc");
+        return;
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let bdwgc_src = PathBuf::from(BDWGC_REPO);
 


### PR DESCRIPTION
This is useful for debugging, where profilers intercept and override dynamically linked symbols (e.g. `malloc` and `free`).

As of this commit, there is no way to build a custom BDWGC fork and have that dynamically link to a program compiled with Alloy automatically. This is because `cargo` does not support bubbling up linker args to the final linked binary, so there is no way to programmatically set the rpath for BDWGC to the OUT directory in `library/bdwgc` [1].

Alloy programs must therefore set the `LD_PRELOAD` environment variable to prevent it from linking against the system libgc.

[1]: https://github.com/rust-lang/cargo/issues/9554