### PR TITLE
Add a function for users to keep pointers alive

### DIFF
--- a/library/bdwgc/src/lib.rs
+++ b/library/bdwgc/src/lib.rs
@@ -84,4 +84,6 @@ extern "C" {
     pub fn GC_ignore_warn_proc(proc: *mut u8, word: usize);
 
     pub fn GC_finalized_total() -> u64;
+
+    pub fn GC_keep_alive(ptr: *mut u8);
 }

--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -173,6 +173,10 @@ pub fn thread_registered() -> bool {
     unsafe { bdwgc::GC_thread_is_registered() != 0 }
 }
 
+pub fn keep_alive<T>(ptr: *mut T) {
+    unsafe { bdwgc::GC_keep_alive(ptr as *mut u8) }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // GC API
 ////////////////////////////////////////////////////////////////////////////////
@@ -231,11 +235,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Gc<U>> for Gc<T> {}
 #[cfg(all(not(bootstrap), not(test)))]
 impl<T: ?Sized> Drop for Gc<T> {
     fn drop(&mut self) {
-        unsafe {
-            // asm macro clobber by default, so this is enough to introduce a
-            // barrier.
-            core::arch::asm!("/* {0} */", in(reg) self);
-        }
+        keep_alive(self);
     }
 }
 


### PR DESCRIPTION
This is useful for advanced users, who may allow references to GC objects to escape from their Gc<T> smart pointers. In such cases, one must be careful to ensure that a finalizer is not run early because of compiler optimisations (e.g. scalar replacement). This commit provides a unified way to do this using the same mechanism as Gc::drop.