### PR TITLE
Refactor FSA error generation

### DIFF
--- a/tests/ui/runtime/gc/check_finalizers.rs
+++ b/tests/ui/runtime/gc/check_finalizers.rs
@@ -68,16 +68,21 @@ impl Drop for ShouldFail3 {
 fn main() {
     Gc::new(ShouldPass(123 as *mut u8));
 
-    Gc::new(ShouldFail(Cell::new(123))); //~ ERROR: `ShouldFail(Cell::new(123))` cannot be safely finalized.
+    Gc::new(ShouldFail(Cell::new(123)));
+    //~^ ERROR: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
+    //~^^ ERROR: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
 
     let gcfields = HasGcFields(Gc::new(123));
-    Gc::new(gcfields); //~ ERROR: `gcfields` cannot be safely finalized.
+    Gc::new(gcfields);
+    //~^ ERROR: `gcfields` has a drop method which cannot be safely finalized.
 
     let self_call = ShouldFail2(123 as *mut u8);
-    Gc::new(self_call); //~ ERROR: `self_call` cannot be safely finalized.
+    Gc::new(self_call);
+    //~^ ERROR: `self_call` has a drop method which cannot be safely finalized.
 
     let not_threadsafe = ShouldFail3(NotThreadSafe(123));
-    Gc::new(not_threadsafe); //~ ERROR: `not_threadsafe` cannot be safely finalized.
+    Gc::new(not_threadsafe);
+    //~^ ERROR: `not_threadsafe` has a drop method which cannot be safely finalized.
 
     unsafe { Gc::new(FinalizeUnchecked::new(ShouldFail(Cell::new(123)))) };
 }

--- a/tests/ui/runtime/gc/check_finalizers.stderr
+++ b/tests/ui/runtime/gc/check_finalizers.stderr
@@ -1,4 +1,4 @@
-error: `ShouldFail(Cell::new(123))` cannot be safely finalized.
+error: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
   --> $DIR/check_finalizers.rs:71:13
    |
 LL |         self.0.replace(456);
@@ -8,13 +8,28 @@ LL |         self.0.replace(456);
    |         it uses a type which is not safe to use in a finalizer.
 ...
 LL |     Gc::new(ShouldFail(Cell::new(123)));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `Send + Sync + FinalizerSafe`.
+           must only use values whose types implement `Send` + `Sync`.
 
-error: `gcfields` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:74:13
+error: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:71:13
+   |
+LL |         self.0.replace(456);
+   |         ------
+   |         |
+   |         caused by the expression in `fn drop(&mut)` here because
+   |         it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(ShouldFail(Cell::new(123)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^- `Gc::new` requires that it implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `gcfields` has a drop method which cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:76:13
    |
 LL |         println!("Boom {}", self.0);
    |                             ------
@@ -23,27 +38,16 @@ LL |         println!("Boom {}", self.0);
    |                             it uses another `Gc` type.
 ...
 LL |     Gc::new(gcfields);
-   |             ^^^^^^^^ has a drop method which cannot be safely finalized.
-   |
-   = help: `Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.
+   |     --------^^^^^^^^- Finalizers cannot safely dereference other `Gc`s, because they might have already been finalised.
 
-error: `self_call` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:77:13
-   |
-LL |         self.foo();
-   |         ----------
-   |         |
-   |         caused by the expression in `fn drop(&mut)` here because
-   |         it uses a type which is not safe to use in a finalizer.
-...
-LL |     Gc::new(self_call);
-   |             ^^^^^^^^^ has a drop method which cannot be safely finalized.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `Send + Sync + FinalizerSafe`.
-
-error: `not_threadsafe` cannot be safely finalized.
+error: `self_call` has a drop method which cannot be safely finalized.
   --> $DIR/check_finalizers.rs:80:13
+   |
+LL |     Gc::new(self_call);
+   |             ^^^^^^^^^ contains a function call which may be unsafe.
+
+error: `not_threadsafe` has a drop method which cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:84:13
    |
 LL |         println!("Boom {}", self.0.0);
    |                             --------
@@ -52,10 +56,10 @@ LL |         println!("Boom {}", self.0.0);
    |                             it uses a type which is not safe to use in a finalizer.
 ...
 LL |     Gc::new(not_threadsafe);
-   |             ^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |             ^^^^^^^^^^^^^^
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `Send + Sync + FinalizerSafe`.
+           must only use values whose types implement `Send` + `Sync`.
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This PR creates a single enum to represent the various kinds of FSA errors that Rust programs may exhibit. This is a mostly refactoring commit which hopes to simplify some more complex analysis that we want to perform.

However, this does have one observable impact on the current state of FSA in Alloy: we now emit different errors for types which are `!Send` + `!Sync`, and those which are `!FinalizerSafe`.

On its own, this may seem extraneous, as it now means that types which are `!Send + !Sync + !FinalizerSafe` will now generate two errors instead of one. However, this vastly simplifies future changes to the FSA algorithm, and makes it much easier to 'bail-out' of FSA early when we find bad cases which would not maek sense to recurse further into (e.g. standard library types).