### PR TITLE
Less granular FSA errors for standard library types

### DIFF
--- a/tests/ui/static/gc/fsa/stdlib_errors.rs
+++ b/tests/ui/static/gc/fsa/stdlib_errors.rs
@@ -1,0 +1,40 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+
+use std::gc::Gc;
+use std::rc::Rc;
+
+// S is FSA-safe but the inner RC is not.
+#[derive(Clone)]
+struct S(Rc<u8>);
+
+struct Unsafe(u8);
+impl !FinalizerSafe for Unsafe {}
+
+// Make sure that FSA still reports an error for the `Unsafe` field.
+struct T(S, Unsafe);
+
+// This should only give a single `Rc` FSA error.
+struct U(Rc<Rc<Rc<u8>>>);
+
+impl Drop for T {
+    fn drop(&mut self) {
+        println!("Boom {}", self.1.0); // deref `Unsafe`
+    }
+}
+
+fn main() {
+    let s = S(Rc::new(1));
+    let t = T(s.clone(), Unsafe(1));
+    let u = U(Rc::new(Rc::new(Rc::new(1))));
+
+    Gc::new(s);
+    //~^ ERROR: `s` has a drop method which cannot be safely finalized.
+
+    Gc::new(t);
+    //~^  ERROR: `t` has a drop method which cannot be safely finalized.
+    //~^^ ERROR: `t` has a drop method which cannot be safely finalized.
+
+    Gc::new(u);
+    //~^ ERROR: `u` has a drop method which cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/stdlib_errors.stderr
+++ b/tests/ui/static/gc/fsa/stdlib_errors.stderr
@@ -1,0 +1,47 @@
+error: `s` has a drop method which cannot be safely finalized.
+  --> $DIR/stdlib_errors.rs:31:13
+   |
+LL |       Gc::new(s);
+   |               ^
+  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
+  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
+   |
+   = note: is not safe to be run as a finalizer
+
+error: `t` has a drop method which cannot be safely finalized.
+  --> $DIR/stdlib_errors.rs:34:13
+   |
+LL |         println!("Boom {}", self.1.0); // deref `Unsafe`
+   |                             --------
+   |                             |
+   |                             caused by the expression in `fn drop(&mut)` here because
+   |                             it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(t);
+   |     --------^- `Gc::new` requires that it implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `t` has a drop method which cannot be safely finalized.
+  --> $DIR/stdlib_errors.rs:34:13
+   |
+LL |       Gc::new(t);
+   |               ^
+  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
+  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
+   |
+   = note: is not safe to be run as a finalizer
+
+error: `u` has a drop method which cannot be safely finalized.
+  --> $DIR/stdlib_errors.rs:38:13
+   |
+LL |       Gc::new(u);
+   |               ^
+  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
+  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
+   |
+   = note: is not safe to be run as a finalizer
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This does not weaken FSA -- the drop methods of standard library types are still scanned line-by-line. However, if a standard library type contains a drop method with an unsafe projection, a single generic error for that type will be emitted (as opposed to errors on a per-line basis as with user crates).