### PR TITLE
Use custom hashbrown implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,14 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "git+https://github.com/softdevteam/alloy_hashbrown?branch=elide_finalisers#c40d6530b95732913ee6c65185784f2ebe56d242"
+dependencies = [
+ "allocator-api2",
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -1995,7 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
  "rustc-rayon",
  "serde",
 ]
@@ -2657,7 +2665,7 @@ dependencies = [
  "compiler_builtins",
  "crc32fast",
  "flate2",
- "hashbrown",
+ "hashbrown 0.14.3",
  "indexmap",
  "memchr",
  "rustc-std-workspace-alloc",
@@ -5278,7 +5286,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hermit-abi",
  "libc",
  "miniz_oxide",
@@ -5585,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4db52ee8fec06e119b692ef3dd2c4cf621a99204c1b8c47407870ed050305b9b"
 dependencies = [
  "gimli",
- "hashbrown",
+ "hashbrown 0.14.3",
  "object 0.32.2",
  "tracing",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -21,7 +21,7 @@ core = { path = "../core", public = true }
 compiler_builtins = { version = "0.1.105" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { git = "https://github.com/softdevteam/alloy_hashbrown", branch = "elide_finalisers", default-features = false, features = ['rustc-dep-of-std'] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const ALLOY_HASHBROWN: &str = "alloy_hashbrown";
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
@@ -33,7 +34,7 @@ pub fn check(root: &Path, bad: &mut bool) {
             let source = line.split_once('=').unwrap().1.trim();
 
             // Ensure source is allowed.
-            if !ALLOWED_SOURCES.contains(&&*source) {
+            if !ALLOWED_SOURCES.contains(&&*source) && !source.contains(ALLOY_HASHBROWN) {
                 tidy_error!(bad, "invalid source: {}", source);
             }
         }

--- a/tests/ui/issues/issue-21763.rs
+++ b/tests/ui/issues/issue-21763.rs
@@ -1,6 +1,6 @@
 // Regression test for HashMap only impl'ing Send/Sync if its contents do
 
-//@ normalize-stderr-test: "\S+[\\/]hashbrown\S+" -> "$$HASHBROWN_SRC_LOCATION"
+//@ normalize-stderr-test: "\S+[\\/]alloy_hashbrown\S+" -> "$$HASHBROWN_SRC_LOCATION"
 
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/tests/ui/static/gc/elision/hashmap.rs
+++ b/tests/ui/static/gc/elision/hashmap.rs
@@ -1,0 +1,27 @@
+//@ run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+use std::mem::needs_finalizer;
+use std::collections::HashMap;
+use std::gc::Gc;
+
+static HM_TRIVIAL: bool = needs_finalizer::<HashMap<usize, usize>>();
+static HM_FIN_KEY: bool = needs_finalizer::<HashMap<HasDrop, HasDropNoFinalize>>();
+static HM_FIN_VAL: bool = needs_finalizer::<HashMap<HasDropNoFinalize, HasDrop>>();
+static HM_FIN_BOTH: bool = needs_finalizer::<HashMap<HasDrop, HasDrop>>();
+static HM_FIN_GC_KEY: bool = needs_finalizer::<HashMap<Gc<HasDropNoFinalize>, Gc<HasDrop>>>();
+static HM_FIN_GC_VAL: bool = needs_finalizer::<HashMap<Gc<HasDropNoFinalize>, Gc<HasDrop>>>();
+static HM_FIN_GC_BOTH: bool = needs_finalizer::<HashMap<Gc<HasDrop>, Gc<HasDrop>>>();
+
+fn main() {
+    assert!(!HM_TRIVIAL);
+    assert!(HM_FIN_KEY);
+    assert!(HM_FIN_VAL);
+    assert!(HM_FIN_BOTH);
+    assert!(!HM_FIN_GC_KEY);
+    assert!(!HM_FIN_GC_VAL);
+    assert!(!HM_FIN_GC_BOTH);
+}

--- a/tests/ui/static/gc/elision/hashset.rs
+++ b/tests/ui/static/gc/elision/hashset.rs
@@ -1,0 +1,41 @@
+//@ run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+use std::mem::needs_finalizer;
+use std::collections::HashSet;
+use std::gc::Gc;
+
+static HS_TRIVIAL: bool = needs_finalizer::<HashSet<usize>>();
+static HS_FINALIZABLE: bool = needs_finalizer::<HashSet<HasDrop>>();
+static HS_UNFINALIZABLE: bool = needs_finalizer::<HashSet<HasDropNoFinalize>>();
+static HS_TUPLE_UNFINALIZABLE: bool = needs_finalizer::<HashSet<(HasDropNoFinalize, usize)>>();
+static HS_TUPLE_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, HasDrop)>>();
+static HS_TUPLE_CONTAINS_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, usize)>>();
+static HS_HS_FINALIZABLE: bool = needs_finalizer::<HashSet<HashSet<HasDrop>>>();
+static HS_HS_UNFINALIZABLE: bool = needs_finalizer::<HashSet<HashSet<HasDropNoFinalize>>>();
+static HS_STRING: bool = needs_finalizer::<HashSet<String>>();
+static HS_BOX_FINALIZABLE: bool = needs_finalizer::<HashSet<Box<HasDrop>>>();
+static HS_BOX_UNFINALIZABLE: bool = needs_finalizer::<HashSet<Box<HasDropNoFinalize>>>();
+static HS_TUPLE_GC_UNFINALIZABLE: bool = needs_finalizer::<HashSet<(HasDropNoFinalize, Gc<HasDrop>)>>();
+static HS_TUPLE_GC_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, Gc<HasDrop>)>>();
+static HS_COLLECTABLE_NO_DROP_ELEMENT: bool = needs_finalizer::<HashSet<NonAnnotated>>();
+
+fn main() {
+    assert!(!HS_TRIVIAL);
+    assert!(HS_FINALIZABLE);
+    assert!(!HS_UNFINALIZABLE);
+    assert!(!HS_TUPLE_UNFINALIZABLE);
+    assert!(HS_TUPLE_FINALIZABLE);
+    assert!(HS_TUPLE_CONTAINS_FINALIZABLE);
+    assert!(HS_HS_FINALIZABLE);
+    assert!(!HS_HS_UNFINALIZABLE);
+    assert!(!HS_STRING);
+    assert!(HS_BOX_FINALIZABLE);
+    assert!(!HS_BOX_UNFINALIZABLE);
+    assert!(!HS_TUPLE_GC_UNFINALIZABLE);
+    assert!(HS_TUPLE_GC_FINALIZABLE);
+    assert!(!HS_COLLECTABLE_NO_DROP_ELEMENT);
+}


### PR DESCRIPTION
This supports finalizer elision by implementing DropMethodFinalizerElidable on the backing table.