### PR TITLE
Allow types containing references to have finalizers

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -284,7 +284,6 @@ symbols! {
         RefCell,
         RefCellRef,
         RefCellRefMut,
-        ReferenceFree,
         Relaxed,
         Release,
         Result,

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -47,13 +47,6 @@ impl<T: ?Sized> DerefMut for NonFinalizable<T> {
     }
 }
 
-#[unstable(feature = "gc", issue = "none")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "ReferenceFree")]
-pub unsafe auto trait ReferenceFree {}
-
-impl<T> !ReferenceFree for &T {}
-impl<T> !ReferenceFree for &mut T {}
-
 /// A wrapper to prevent alloy from performing Finaliser Safety Analysis (FSA)
 /// on `T`.
 ///
@@ -96,6 +89,3 @@ impl<T: ?Sized> DerefMut for FinalizeUnchecked<T> {
 
 #[cfg(not(bootstrap))]
 unsafe impl<T> FinalizerSafe for FinalizeUnchecked<T> {}
-
-#[cfg(not(bootstrap))]
-unsafe impl<T> ReferenceFree for FinalizeUnchecked<T> {}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -623,6 +623,11 @@ impl<T: ?Sized> !FinalizerSafe for *const T {}
 #[unstable(feature = "gc", issue = "none")]
 impl<T: ?Sized> !FinalizerSafe for *mut T {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for &T {}
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for &mut T {}
+
 /// Zero-sized type used to mark things that "act like" they own a `T`.
 ///
 /// Adding a `PhantomData<T>` field to your type tells the compiler that your

--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -560,7 +560,7 @@ impl<T> GcBox<MaybeUninit<T>> {
 
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "gc", issue = "none")]
-impl<T: Default + Send + Sync + ReferenceFree> Default for Gc<T> {
+impl<T: Default + Send + Sync> Default for Gc<T> {
     /// Creates a new `Gc<T>`, with the `Default` value for `T`.
     ///
     /// # Examples

--- a/tests/rustdoc/auto-trait-bounds-by-associated-type-50159.rs
+++ b/tests/rustdoc/auto-trait-bounds-by-associated-type-50159.rs
@@ -20,7 +20,7 @@ where
 // @has - '//h3[@class="code-header"]' 'impl<B> Send for Switch<B>where <B as Signal>::Item: Send'
 // @has - '//h3[@class="code-header"]' 'impl<B> Sync for Switch<B>where <B as Signal>::Item: Sync'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 8
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 7
 pub struct Switch<B: Signal> {
     pub inner: <B as Signal2>::Item2,
 }

--- a/tests/rustdoc/empty-section.rs
+++ b/tests/rustdoc/empty-section.rs
@@ -12,4 +12,3 @@ impl !FinalizerSafe for Foo {}
 impl !std::marker::Unpin for Foo {}
 impl !std::panic::RefUnwindSafe for Foo {}
 impl !std::panic::UnwindSafe for Foo {}
-unsafe impl std::gc::ReferenceFree for Foo {}

--- a/tests/rustdoc/synthetic_auto/basic.rs
+++ b/tests/rustdoc/synthetic_auto/basic.rs
@@ -2,7 +2,7 @@
 // @has - '//h3[@class="code-header"]' 'impl<T> Send for Foo<T>where T: Send'
 // @has - '//h3[@class="code-header"]' 'impl<T> Sync for Foo<T>where T: Sync'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 8
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 7
 pub struct Foo<T> {
     field: T,
 }

--- a/tests/rustdoc/synthetic_auto/manual.rs
+++ b/tests/rustdoc/synthetic_auto/manual.rs
@@ -6,7 +6,7 @@
 // 'impl<T> Send for Foo<T>'
 //
 // @count - '//*[@id="trait-implementations-list"]//*[@class="impl"]' 1
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 7
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 6
 pub struct Foo<T> {
     field: T,
 }

--- a/tests/ui/runtime/gc/check_finalizers.rs
+++ b/tests/ui/runtime/gc/check_finalizers.rs
@@ -70,7 +70,6 @@ fn main() {
 
     Gc::new(ShouldFail(Cell::new(123)));
     //~^ ERROR: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
-    //~^^ ERROR: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
 
     let gcfields = HasGcFields(Gc::new(123));
     Gc::new(gcfields);

--- a/tests/ui/runtime/gc/check_finalizers.stderr
+++ b/tests/ui/runtime/gc/check_finalizers.stderr
@@ -13,23 +13,8 @@ LL |     Gc::new(ShouldFail(Cell::new(123)));
    = help: `Gc` runs finalizers on a separate thread, so drop methods
            must only use values whose types implement `Send` + `Sync`.
 
-error: `ShouldFail(Cell::new(123))` has a drop method which cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:71:13
-   |
-LL |         self.0.replace(456);
-   |         ------
-   |         |
-   |         caused by the expression in `fn drop(&mut)` here because
-   |         it uses a type which is not safe to use in a finalizer.
-...
-LL |     Gc::new(ShouldFail(Cell::new(123)));
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^- `Gc::new` requires that it implements the `FinalizeSafe` trait.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
-
 error: `gcfields` has a drop method which cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:76:13
+  --> $DIR/check_finalizers.rs:75:13
    |
 LL |         println!("Boom {}", self.0);
    |                             ------
@@ -41,13 +26,13 @@ LL |     Gc::new(gcfields);
    |     --------^^^^^^^^- Finalizers cannot safely dereference other `Gc`s, because they might have already been finalised.
 
 error: `self_call` has a drop method which cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:80:13
+  --> $DIR/check_finalizers.rs:79:13
    |
 LL |     Gc::new(self_call);
    |             ^^^^^^^^^ contains a function call which may be unsafe.
 
 error: `not_threadsafe` has a drop method which cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:84:13
+  --> $DIR/check_finalizers.rs:83:13
    |
 LL |         println!("Boom {}", self.0.0);
    |                             --------
@@ -61,5 +46,5 @@ LL |     Gc::new(not_threadsafe);
    = help: `Gc` runs finalizers on a separate thread, so drop methods
            must only use values whose types implement `Send` + `Sync`.
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/static/gc/fsa/auxiliary/types.rs
+++ b/tests/ui/static/gc/fsa/auxiliary/types.rs
@@ -1,0 +1,44 @@
+#[inline(never)]
+fn use_val<T: std::fmt::Debug>(x: T) {
+    dbg!("{:?}", x);
+}
+
+#[derive(Debug)]
+struct HasNestedRef<'a> {
+    a: &'a u64,
+    b: u64,
+    c: HasRef<'a>,
+}
+
+#[derive(Debug)]
+struct HasRef<'a> {
+    a: &'a u64,
+    b: u64,
+    c: [&'a u64; 2]
+}
+
+impl<'a> HasRef<'a> {
+    #[inline(never)]
+    fn new(a: &'a u64, b: u64, c: [&'a u64; 2]) -> Self {
+        Self { a, b, c }
+    }
+
+    #[inline(always)]
+    fn new_inlined(a: &'a u64, b: u64, c: [&'a u64; 2]) -> Self {
+        Self { a, b, c }
+    }
+}
+
+impl<'a> std::default::Default for HasRef<'a> {
+    #[inline(never)]
+    fn default() -> Self {
+        Self { a: &1, b: 1, c: [&1, &2] }
+    }
+}
+
+impl<'a> std::default::Default for HasNestedRef<'a> {
+    #[inline(never)]
+    fn default() -> Self {
+        Self { a: &1, b: 1, c: HasRef::default() }
+    }
+}

--- a/tests/ui/static/gc/fsa/references.rs
+++ b/tests/ui/static/gc/fsa/references.rs
@@ -1,0 +1,31 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+include!{"./auxiliary/types.rs"}
+
+impl<'a> Drop for HasRef<'a> {
+    fn drop(&mut self) {
+        use_val(self.a); // should fail
+        use_val(self.b); // should pass
+        use_val(self.c[0]); // should fail
+
+        let a = self.a; // should fail
+        let b = self.b; // should pass
+        let c = self.c;
+        use_val(c[1]); // should fail
+
+        // should pass, as not a field projection
+        let c = &1;
+        use_val(c);
+    }
+}
+
+fn main() {
+    std::gc::Gc::new(HasRef::default());
+    //~^     ERROR: `HasRef::default()` has a drop method which cannot be safely finalized.
+    //~^^    ERROR: `HasRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^   ERROR: `HasRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^^  ERROR: `HasRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^^^ ERROR: `HasRef::default()` has a drop method which cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/references.stderr
+++ b/tests/ui/static/gc/fsa/references.stderr
@@ -1,0 +1,74 @@
+error: `HasRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references.rs:25:22
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasRef::default());
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: `HasRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references.rs:25:22
+   |
+LL |         use_val(self.c[0]); // should fail
+   |                 ---------
+   |                 |
+   |                 caused by the expression in `fn drop(&mut)` here because
+   |                 it uses a type which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasRef::default());
+   |     -----------------^^^^^^^^^^^^^^^^^- `Gc::new` requires that [&u64; 2] implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `HasRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references.rs:25:22
+   |
+LL |         let a = self.a; // should fail
+   |                 ------
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasRef::default());
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: `HasRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references.rs:25:22
+   |
+LL |         let c = self.c;
+   |                 ------
+   |                 |
+   |                 caused by the expression in `fn drop(&mut)` here because
+   |                 it uses a type which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasRef::default());
+   |     -----------------^^^^^^^^^^^^^^^^^- `Gc::new` requires that [&u64; 2] implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `HasRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references.rs:25:22
+   |
+LL |         use_val(c[1]); // should fail
+   |                 ----
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasRef::default());
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/static/gc/fsa/references_nested.rs
+++ b/tests/ui/static/gc/fsa/references_nested.rs
@@ -1,0 +1,44 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+include!{"./auxiliary/types.rs"}
+
+impl<'a> Drop for HasNestedRef<'a> {
+    fn drop(&mut self) {
+        use_val(self.a); // should fail
+        use_val(self.b); // should pass
+
+        // Project through to the nested `HasRef` struct.
+        use_val(self.c.a); // should fail
+        use_val(self.c.b); // should pass
+
+        let a = self.a; // should fail
+        let b = self.b; // should pass
+
+        let ca = self.a; // should fail
+        let cb = self.b; // should pass
+
+        // should pass, as not a field projection
+        let d = &1;
+        use_val(d);
+
+        let e = HasRef::default();
+        // Should fail as it is a field projection. Ideally this should be allowed because these
+        // references are not fields on the `self` type. However, FSA is not sophisticated enough to
+        // make this distinction.
+        use_val(e.a);
+        // Should pass
+        use_val(e.b);
+    }
+}
+
+fn main() {
+    std::gc::Gc::new(HasNestedRef::default());
+    //~^     ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+    //~^^    ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^   ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^^  ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^^^ ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+    //~^^^^^^ERROR: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/references_nested.stderr
+++ b/tests/ui/static/gc/fsa/references_nested.stderr
@@ -1,0 +1,88 @@
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         use_val(self.c.a); // should fail
+   |                 --------
+   |                 |
+   |                 caused by the expression in `fn drop(&mut)` here because
+   |                 it uses a type which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^- `Gc::new` requires that HasRef<'_> implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         use_val(self.c.b); // should pass
+   |                 --------
+   |                 |
+   |                 caused by the expression in `fn drop(&mut)` here because
+   |                 it uses a type which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^- `Gc::new` requires that HasRef<'_> implements the `FinalizeSafe` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         let a = self.a; // should fail
+   |                 ------
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         let ca = self.a; // should fail
+   |                  ------
+   |                  |
+   |                  caused by the expression here in `fn drop(&mut)` because
+   |                  it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: `HasNestedRef::default()` has a drop method which cannot be safely finalized.
+  --> $DIR/references_nested.rs:37:22
+   |
+LL |         use_val(e.a);
+   |                 ---
+   |                 |
+   |                 caused by the expression here in `fn drop(&mut)` because
+   |                 it is a reference (&u64) which is not safe to use in a finalizer.
+...
+LL |     std::gc::Gc::new(HasNestedRef::default());
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/static/gc/fsa/stdlib_errors.stderr
+++ b/tests/ui/static/gc/fsa/stdlib_errors.stderr
@@ -18,7 +18,7 @@ LL |         println!("Boom {}", self.1.0); // deref `Unsafe`
    |                             it uses a type which is not safe to use in a finalizer.
 ...
 LL |     Gc::new(t);
-   |     --------^- `Gc::new` requires that it implements the `FinalizeSafe` trait.
+   |     --------^- `Gc::new` requires that Unsafe implements the `FinalizeSafe` trait.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
            must only use values whose types implement `FinalizerSafe`.


### PR DESCRIPTION
Previously FSA prevented `Gc<T>`s from having a finalizer if `T` (directly or indirectly) contained a reference. This made retro-fitting GC to large libraries difficult. It also, somewhat surprisingly, completely prevents finalizable nested `Gc<dyn Trait>`s (due to the underlying vptr being a `&'static` reference).

This commit loosens this restriction, allowing FSA to interrogate drop method bodies (much the same as for `Send + Sync + FinalizerSafe`) looking for unsound uses of references.

This change is based on the following observation: a reference inside of `T`'s drop method is safe to dereference provided it never originates from `T` or one of `T`'s fields. For example:

```rust
fn drop(&mut self) {
    let a = 123;

    let r1 = &1; // const with 'static lifetime
    let r2 = &a; // stack-local
    let r3 = &*(unsafe { ... }); // unsafe code, all bets are off.

    let r4: &u64 = self.a;
    let r5: &u64 = self.b.a;
    let r6: &u64 = self.c[0]; // c: [&u64; 2]
}
```

In this example, `r1`, `r2`, and `r3` are allowed by FSA: `r1` and `r2` are sound because their referent will always be valid when the finalizer is called. `r3` uses unsafe code, so FSA gets out of the way here, as it is up to the user to ensure that this is sound themselves.

`r4`, `r5`, and `r6` on the other hand are not allowed by FSA. This is because they are references which are obtained through field or array index projections into `T`. Such projections are nearly always unsound, so we always prevent these.

This change means that we can remove the `ReferenceFree` trait, since we now always check for references inside a drop method. As with our relaxed FSA rules for `FinalizerSafe` and friends -- if for any reason we can't see into a type, we err on the side of caution and emit an error.