### PR TITLE
Prevent unnecessary trait resolution

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1348,6 +1348,18 @@ rustc_queries! {
     query drop_method_finalizer_elidable_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
         desc { "computing whether `{}` contains types which might need finalizing", env.value }
     }
+    /// Query backing `Ty::is_finalizer_safe`.
+    query is_finalizer_safe_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+        desc { "computing whether `{}` is `FinalizerSafe`", env.value }
+    }
+    /// Query backing `Ty::is_send`.
+    query is_send_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+        desc { "computing whether `{}` is `Send`", env.value }
+    }
+    /// Query backing `Ty::is_sync`.
+    query is_sync_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+        desc { "computing whether `{}` is `Sync`", env.value }
+    }
     /// Query backing `Ty::needs_drop`.
     query needs_drop_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
         desc { "computing whether `{}` needs drop", env.value }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1219,7 +1219,16 @@ impl<'tcx> Ty<'tcx> {
 
     pub fn is_gc(self, tcx: TyCtxt<'tcx>) -> bool {
         if let ty::Adt(adt_def, ..) = self.kind() {
-            return tcx.get_diagnostic_item(sym::gc).map_or(false, |gc| adt_def.did() == gc);
+            return tcx.get_diagnostic_item(sym::gc).map_or(false, |t| adt_def.did() == t);
+        }
+        return false;
+    }
+
+    pub fn is_finalize_unchecked(self, tcx: TyCtxt<'tcx>) -> bool {
+        if let ty::Adt(adt_def, ..) = self.kind() {
+            return tcx
+                .get_diagnostic_item(sym::FinalizeUnchecked)
+                .map_or(false, |t| adt_def.did() == t);
         }
         return false;
     }
@@ -1241,6 +1250,18 @@ impl<'tcx> Ty<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
     ) -> bool {
         tcx.drop_method_finalizer_elidable_raw(param_env.and(self))
+    }
+
+    pub fn is_finalizer_safe(self, tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> bool {
+        tcx.is_finalizer_safe_raw(param_env.and(self))
+    }
+
+    pub fn is_send(self, tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> bool {
+        tcx.is_send_raw(param_env.and(self))
+    }
+
+    pub fn is_sync(self, tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> bool {
+        tcx.is_sync_raw(param_env.and(self))
     }
 
     /// Fast path helper for testing if a type is `Freeze`.

--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -9,8 +9,6 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt};
 use rustc_span::symbol::sym;
 use rustc_span::Span;
-use rustc_trait_selection::infer::InferCtxtExt as _;
-use rustc_trait_selection::infer::TyCtxtInferExt;
 
 #[derive(PartialEq)]
 pub struct CheckFinalizers;
@@ -49,7 +47,7 @@ impl<'tcx> FinalizerErrorKind<'tcx> {
             }
             Self::NotFinalizerSafe(ty, span) => {
                 // Special-case `Gc` types for more friendly errors
-                if cx.is_gc(*ty) {
+                if ty.is_gc(cx.tcx) {
                     err.span_label(
                         *span,
                         "caused by the expression here in `fn drop(&mut)` because",
@@ -106,6 +104,14 @@ impl<'tcx> MirPass<'tcx> for CheckFinalizers {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let param_env = tcx.param_env(body.source.def_id());
 
+        if in_std_lib(tcx, body.source.def_id()) {
+            // Do not check for FSA entry points if we're compiling the standard library. This is
+            // because in practice, the only entry points would be `Gc` constructor calls in the
+            // implementation of the `Gc` API (`library/std/gc.rs`), and we don't want to check
+            // these.
+            return;
+        }
+
         for (func, args, source_info) in
             body.basic_blocks.iter().filter_map(|bb| match &bb.terminator().kind {
                 TerminatorKind::Call { func, args, .. } => {
@@ -114,46 +120,95 @@ impl<'tcx> MirPass<'tcx> for CheckFinalizers {
                 _ => None,
             })
         {
-            let ty::FnDef(fn_did, ..) = func.ty(body, tcx).kind() else {
-                // We only care about explicit function calls.
+            let fn_ty = func.ty(body, tcx);
+            let ty::FnDef(fn_did, substs) = fn_ty.kind() else {
+                // We don't care about function pointers, but we'll assert here incase there's
+                // another kind of type we haven't accounted for.
+                assert!(fn_ty.is_fn_ptr());
                 continue;
             };
-            if !tcx.has_attr(*fn_did, sym::rustc_fsa_entry_point) {
+
+            // The following is a gross hack for performance reasons!
+            //
+            // Calls in MIR which are trait method invocations point to the DefId
+            // of the trait definition, and *not* the monomorphized concrete method definition.
+            // This is a problem for us, because e.g. the `Gc::from` function definition will have the
+            // `#[rustc_fsa_entry_point]` attribute, but the generic `T::from` definition will
+            // not. This is a problem for us, because naively it means we must monomorphize
+            // every single function call just to see if it points to a function somewhere inside
+            // the `Gc` library with the desired attribute. This is painfully slow!
+            //
+            // To get around this, we can ignore all calls if they do not do both of the following:
+            //
+            //      a) point to some function in the standard library.
+            //
+            //      b) the generic substitution for the return type (which is readily available) is
+            //      not a `Gc<T>`. In practice, this means we only actually end up having to
+            //      resolve fn calls to their precise instance when they actually are some kind
+            //      of `Gc` constructor (we still check for the attribute later on to make sure
+            //      though!).
+            if !in_std_lib(tcx, *fn_did) || !fn_ty.fn_sig(tcx).output().skip_binder().is_gc(tcx) {
+                continue;
+            }
+            let mono_fn_did = ty::Instance::resolve(tcx, param_env, *fn_did, substs)
+                .unwrap()
+                .unwrap()
+                .def
+                .def_id();
+            if !tcx.has_attr(mono_fn_did, sym::rustc_fsa_entry_point) {
                 // Skip over any call that's not marked #[rustc_fsa_entry_point]
                 continue;
             }
 
             assert_eq!(args.len(), 1);
             let arg_ty = args[0].node.ty(body, tcx);
-            FinalizationCtxt::new(source_info.span, args[0].span, tcx, param_env)
-                .check_drop_glue(arg_ty);
+            FinalizationCtxt::new(source_info.span, args[0].span, arg_ty, tcx, param_env)
+                .check_drop_glue();
         }
     }
 }
 
+/// The central data structure for performing FSA. Constructed and used each time a new FSA
+/// entry-point is found in the MIR (e.g. a call to `Gc::new` or `Gc::from`).
 struct FinalizationCtxt<'tcx> {
+    /// Span of the entry point.
     fn_span: Span,
+    /// Span of the argument to the entry point.
     arg_span: Span,
+    /// Type of the arg to the entry point. This could be deduced from the field above but it is
+    /// inconvenient.
+    arg_ty: Ty<'tcx>,
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
 }
 
 impl<'tcx> FinalizationCtxt<'tcx> {
-    fn new(fn_span: Span, arg_span: Span, tcx: TyCtxt<'tcx>, param_env: ParamEnv<'tcx>) -> Self {
-        Self { fn_span, arg_span, tcx, param_env }
+    fn new(
+        fn_span: Span,
+        arg_span: Span,
+        arg_ty: Ty<'tcx>,
+        tcx: TyCtxt<'tcx>,
+        param_env: ParamEnv<'tcx>,
+    ) -> Self {
+        Self { fn_span, arg_span, arg_ty, tcx, param_env }
     }
 
-    fn check_drop_glue(&self, ty: Ty<'tcx>) {
-        if !self.tcx.needs_finalizer_raw(self.param_env.and(ty)) || self.is_finalize_unchecked(ty) {
+    fn check_drop_glue(&self) {
+        if !self.arg_ty.needs_finalizer(self.tcx, self.param_env)
+            || self.arg_ty.is_finalize_unchecked(self.tcx)
+        {
             return;
         }
 
-        if self.is_send(ty) && self.is_sync(ty) && self.is_finalizer_safe(ty) {
+        if self.arg_ty.is_send(self.tcx, self.param_env)
+            && self.arg_ty.is_sync(self.tcx, self.param_env)
+            && self.arg_ty.is_finalizer_safe(self.tcx, self.param_env)
+        {
             return;
         }
 
         let mut errors = Vec::new();
-        let mut tys = vec![ty];
+        let mut tys = vec![self.arg_ty];
 
         loop {
             let Some(ty) = tys.pop() else {
@@ -192,7 +247,7 @@ impl<'tcx> FinalizationCtxt<'tcx> {
                         tys.push(f)
                     }
                 }
-                ty::Adt(def, substs) if !self.is_copy(ty) => {
+                ty::Adt(def, substs) if !ty.is_copy_modulo_regions(self.tcx, self.param_env) => {
                     if def.is_box() {
                         // This is a special case because Box has an empty drop
                         // method which is filled in later by the compiler.
@@ -200,7 +255,7 @@ impl<'tcx> FinalizationCtxt<'tcx> {
                     }
                     if def.has_dtor(self.tcx) {
                         match DropMethodChecker::new(self.drop_mir(ty), self).check() {
-                            Err(_) if self.in_std_lib(def.did()) => {
+                            Err(_) if in_std_lib(self.tcx, def.did()) => {
                                 errors.push(FinalizerErrorKind::UnsoundExternalDropGlue(
                                     self.drop_mir(ty).span,
                                 ));
@@ -235,68 +290,6 @@ impl<'tcx> FinalizationCtxt<'tcx> {
         let s = self.tcx.mk_args_trait(ty, substs.into_iter());
         let i = ty::Instance::resolve(self.tcx, self.param_env, df, s).unwrap().unwrap();
         self.tcx.instance_mir(i.def)
-    }
-
-    fn in_std_lib(&self, did: DefId) -> bool {
-        let alloc_crate =
-            self.tcx.get_diagnostic_item(sym::Rc).map_or(false, |x| did.krate == x.krate);
-        let core_crate =
-            self.tcx.get_diagnostic_item(sym::RefCell).map_or(false, |x| did.krate == x.krate);
-        let std_crate =
-            self.tcx.get_diagnostic_item(sym::Mutex).map_or(false, |x| did.krate == x.krate);
-        alloc_crate || std_crate || core_crate
-    }
-
-    fn is_finalizer_safe(&self, ty: Ty<'tcx>) -> bool {
-        let t = self.tcx.get_diagnostic_item(sym::FinalizerSafe).unwrap();
-        return self
-            .tcx
-            .infer_ctxt()
-            .build()
-            .type_implements_trait(t, [ty], self.param_env)
-            .must_apply_modulo_regions();
-    }
-
-    fn is_copy(&self, ty: Ty<'tcx>) -> bool {
-        ty.is_copy_modulo_regions(self.tcx, self.param_env)
-    }
-
-    fn is_send(&self, ty: Ty<'tcx>) -> bool {
-        let t = self.tcx.get_diagnostic_item(sym::Send).unwrap();
-        return self
-            .tcx
-            .infer_ctxt()
-            .build()
-            .type_implements_trait(t, [ty], self.param_env)
-            .must_apply_modulo_regions();
-    }
-
-    fn is_sync(&self, ty: Ty<'tcx>) -> bool {
-        let t = self.tcx.get_diagnostic_item(sym::Sync).unwrap();
-        return self
-            .tcx
-            .infer_ctxt()
-            .build()
-            .type_implements_trait(t, [ty], self.param_env)
-            .must_apply_modulo_regions();
-    }
-
-    fn is_gc(&self, ty: Ty<'tcx>) -> bool {
-        if let ty::Adt(def, ..) = ty.kind() {
-            if def.did() == self.tcx.get_diagnostic_item(sym::gc).unwrap() {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    fn is_finalize_unchecked(&self, ty: Ty<'tcx>) -> bool {
-        if let ty::Adt(def, ..) = ty.kind() {
-            if def.did() == self.tcx.get_diagnostic_item(sym::FinalizeUnchecked).unwrap() {
-                return true;
-            }
-        }
-        return false;
     }
 
     /// For a given projection, extract the 'useful' type which needs checking for finalizer safety.
@@ -382,7 +375,9 @@ impl<'a, 'tcx> Visitor<'tcx> for DropMethodChecker<'a, 'tcx> {
             .filter_map(|(base, elem)| self.cx.extract_projection_ty(self.body, base, elem))
         {
             let span = self.body.source_info(location).span;
-            if !self.cx.is_send(ty) || !self.cx.is_sync(ty) {
+            if !ty.is_send(self.cx.tcx, self.cx.param_env)
+                || !ty.is_sync(self.cx.tcx, self.cx.param_env)
+            {
                 self.push_error(location, FinalizerErrorKind::NotSendAndSync(span));
                 break;
             }
@@ -397,7 +392,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DropMethodChecker<'a, 'tcx> {
                 self.push_error(location, FinalizerErrorKind::UnsoundReference(ty, span));
                 break;
             }
-            if !self.cx.is_finalizer_safe(ty) {
+            if !ty.is_finalizer_safe(self.cx.tcx, self.cx.param_env) {
                 self.push_error(location, FinalizerErrorKind::NotFinalizerSafe(ty, span));
                 break;
             }
@@ -451,4 +446,11 @@ impl<'a, 'tcx> Visitor<'tcx> for DropMethodChecker<'a, 'tcx> {
             }
         }
     }
+}
+
+fn in_std_lib<'tcx>(tcx: TyCtxt<'tcx>, did: DefId) -> bool {
+    let alloc_crate = tcx.get_diagnostic_item(sym::Rc).map_or(false, |x| did.krate == x.krate);
+    let core_crate = tcx.get_diagnostic_item(sym::RefCell).map_or(false, |x| did.krate == x.krate);
+    let std_crate = tcx.get_diagnostic_item(sym::Mutex).map_or(false, |x| did.krate == x.krate);
+    alloc_crate || std_crate || core_crate
 }


### PR DESCRIPTION
Trait resolution (and monomorphization, which can be thought of as a variant of this) is used throughout the FSA algorithm (e.g. checking if `T` implements `Send` / `Sync`, resolving calls to trait methods to their concrete implementation, etc). Unfortunately this can be slow, particularly during a MIR pass, where functions must be monomorphized on demand. This slowdown becomes particularly apparent when trying to extend FSA to look into other function calls which are reachable via drop. On large codebases like rustc (e.g. when bootstrapping) or Alacritty, this can lead to over a 2x slowdown in compile time.

The good news is that it's fairly easy to fix this. This commit does this using two simple tricks:

1. We now make use of rustc's internal type-query caching by implementing our "does T implement Trait" methods directly on the `Ty`.
2.  We prevent monomorphizing trait methods unless we really need to by adding more trivial checks which let us bail out on the fast path.

These two changes are enough to put us back in the range of about 1-2% compile-time slowdown for FSA for `Gc` heavy programs, and almost indistinguishable for programs which don't use `Gc`.