### PR TITLE
Perform FSA on a GC entry point's return type

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2025,6 +2025,14 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
+    /// Panics if called on any type other than `Gc<T>`.
+    pub fn gced_ty(self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        match self.kind() {
+            Adt(_, args) if self.is_gc(tcx) => args.type_at(0),
+            _ => bug!("`gced_ty` is called on non-GC type {:?}", self),
+        }
+    }
+
     /// A scalar type is one that denotes an atomic datum, with no sub-components.
     /// (A RawPtr is scalar because it represents a non-managed pointer, so its
     /// contents are abstract to rustc.)

--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -683,7 +683,7 @@ impl<T> From<T> for Gc<T> {
     /// ```
     #[cfg_attr(not(bootstrap), rustc_fsa_entry_point)]
     fn from(t: T) -> Self {
-        Gc::new(t)
+        unsafe { Gc::new_internal(t) }
     }
 }
 

--- a/tests/ui/static/gc/fsa/gc_from.rs
+++ b/tests/ui/static/gc/fsa/gc_from.rs
@@ -1,0 +1,27 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+impl<'a> Drop for HasRef<'a> {
+    fn drop(&mut self) {
+        use_val(self.a); // should fail
+    }
+}
+
+fn main() {
+    let _: Gc<HasRef> = Gc::from(HasRef::default());
+    //~^ ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    let _: Gc<HasRef> = Gc::from(Box::new(HasRef::default()));
+    //~^ ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    let _: Gc<[HasRef]> = Gc::from(vec![HasRef::default()]);
+    //~^ ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    let _: Gc<[HasRef]> = Gc::from(vec![HasRef::default()].into_boxed_slice());
+    //~^ ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+
+    // The following should all pass.
+    let _: Gc<u8> = Gc::from(1);
+    let _: Gc<u8> = Gc::from(Box::new(1));
+    let _: Gc<[u8]> = Gc::from(vec![1, 2, 3]);
+    let _: Gc<[u8]> = Gc::from(vec![1, 2, 3].into_boxed_slice());
+}

--- a/tests/ui/static/gc/fsa/gc_from.stderr
+++ b/tests/ui/static/gc/fsa/gc_from.stderr
@@ -1,0 +1,59 @@
+error: The drop method for `HasRef<'_>` cannot be safely finalized.
+  --> $DIR/gc_from.rs:13:34
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
+...
+LL |     let _: Gc<HasRef> = Gc::from(HasRef::default());
+   |                         ---------^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasRef<'_>>` here.
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: The drop method for `HasRef<'_>` cannot be safely finalized.
+  --> $DIR/gc_from.rs:15:34
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
+...
+LL |     let _: Gc<HasRef> = Gc::from(Box::new(HasRef::default()));
+   |                         ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasRef<'_>>` here.
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: The drop method for `HasRef<'_>` cannot be safely finalized.
+  --> $DIR/gc_from.rs:17:36
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
+...
+LL |     let _: Gc<[HasRef]> = Gc::from(vec![HasRef::default()]);
+   |                           ---------^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<[HasRef<'_>]>` here.
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: The drop method for `HasRef<'_>` cannot be safely finalized.
+  --> $DIR/gc_from.rs:19:36
+   |
+LL |         use_val(self.a); // should fail
+   |                 ------
+   |                 |
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
+...
+LL |     let _: Gc<[HasRef]> = Gc::from(vec![HasRef::default()].into_boxed_slice());
+   |                           ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<[HasRef<'_>]>` here.
+   |
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Previously, when we encountered a GC FSA entry-point (e.g. `Gc::new`) we performed FSA on the argument type of that entry point. When `Gc::new` was our only entry point, this worked fine, because it would always resolve to the `T` in `Gc<T>`.

However, with the addition the of `Gc::from` conversion trait entry point, we can end up being overly conservative with FSA for no good reason. Consider the following:

```rust
    let x: Gc<HasRef> = Gc::from(Box::new(HasRef::default()));
```

Where the argument type to this entry-point is `Box<HasRef>`, but the actual constructed `Gc` type is `Gc<HasRef>`. Using our previous approach, we would have to perform FSA on `Box<HasRef>`, even though the `Box` is never used in the context of GC. On large codebases, this lead to FSA rejecting sound `Gc<T>`s.

This commit therefore tweaks FSA to check the return type of an entry-point, which should always be some `Gc<T>` (we assert! this, because if it isn't, something has gone very wrong.)