### PR TITLE
Load monomorphized versions of MIR in FSA 

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -227,9 +227,17 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                         )));
                     }
                     if def.has_dtor(self.tcx) {
-                        match DropCtxt::new(self.drop_mir(ty), ty, self).check() {
+                        let drop_trait_did = self.tcx.require_lang_item(LangItem::Drop, None);
+                        let poly_drop_fn_did = self.tcx.associated_item_def_ids(drop_trait_did)[0];
+                        let drop_instance = ty::Instance::expect_resolve(
+                            self.tcx,
+                            self.param_env,
+                            poly_drop_fn_did,
+                            self.tcx.mk_args_trait(ty, substs.into_iter()),
+                        );
+                        match DropCtxt::new(drop_instance, ty, self).check() {
                             Err(_) if in_std_lib(self.tcx, def.did()) => {
-                                let fn_info = FnInfo::new(self.drop_mir(ty).span, ty);
+                                let fn_info = FnInfo::new(rustc_span::DUMMY_SP, ty);
                                 errors.push(FinalizerErrorKind::UnsoundExternalDropGlue(fn_info));
                                 // We skip checking the drop methods of this standard library
                                 // type's fields -- we already know that it has an unsafe finaliser, so
@@ -253,15 +261,20 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
         errors.into_iter().for_each(|e| self.emit_error(e));
     }
 
-    fn drop_mir<'a>(&self, ty: Ty<'tcx>) -> &'a Body<'tcx> {
-        let ty::Adt(_, substs) = ty.kind() else {
-            bug!();
-        };
-        let dt = self.tcx.require_lang_item(LangItem::Drop, None);
-        let df = self.tcx.associated_item_def_ids(dt)[0];
-        let s = self.tcx.mk_args_trait(ty, substs.into_iter());
-        let i = ty::Instance::expect_resolve(self.tcx, self.param_env, df, s);
-        self.tcx.instance_mir(i.def)
+    /// Attempts to load the monomorphized version of a MIR body for the given instance if it's
+    /// available. If such MIR is not available then it will load the polymorphic MIR body.
+    fn prefer_instantiated_mir(&self, instance: ty::Instance<'tcx>) -> Option<Body<'tcx>> {
+        if !self.tcx.is_mir_available(instance.def_id()) {
+            return None;
+        }
+        let mir = self.tcx.instance_mir(instance.def);
+        instance
+            .try_instantiate_mir_and_normalize_erasing_regions(
+                self.tcx,
+                self.param_env,
+                ty::EarlyBinder::bind(mir.clone()),
+            )
+            .ok()
     }
 
     /// For a given projection, extract the 'useful' type which needs checking for finalizer safety.
@@ -380,7 +393,10 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                     self.arg_span,
                     format!("The drop method for `{0}` cannot be safely finalized.", fi.drop_ty),
                 );
-                err.span_label(fi.span, "is not safe to be run as a finalizer");
+                err.span_label(
+                    fi.span,
+                    format!("this `{0}` is not safe to be run as a finalizer", fi.drop_ty),
+                );
             }
         }
         err.span_label(
@@ -398,9 +414,9 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
 /// added in `FSAEntryPointCtxt::check_drop_glue()` to the stack of types to be processed
 /// separately, where they get their own `DropCtxt`.
 struct DropCtxt<'ecx, 'tcx> {
-    /// Queue of function definitions that need to be checked as part of this FSA pass. This is
+    /// Queue of function instances that need to be checked as part of this FSA pass. This is
     /// pushed to when a call is located in the MIR.
-    funcs: VecDeque<&'ecx Body<'tcx>>,
+    callsites: VecDeque<ty::Instance<'tcx>>,
     /// The type of the value whose drop method we are currently checking. Used for emitting nicer,
     /// contextual FSA error messages.
     drop_ty: Ty<'tcx>,
@@ -412,35 +428,36 @@ struct DropCtxt<'ecx, 'tcx> {
     /// for the same function definition more than once. Second, and more importantly, this allows
     /// us to deal with recursive function calls. Without this, recursive calls in `drop` would
     /// cause FSA to loop forever.
-    visited_fns: FxHashSet<DefId>,
-}
-
-struct FuncCtxt<'dcx, 'ecx, 'tcx> {
-    body: &'ecx Body<'tcx>,
-    dcx: &'dcx mut DropCtxt<'ecx, 'tcx>,
-    errors: Vec<FinalizerErrorKind<'tcx>>,
-    error_locs: FxHashSet<Location>,
+    visited_fns: FxHashSet<ty::Instance<'tcx>>,
 }
 
 impl<'ecx, 'tcx> DropCtxt<'ecx, 'tcx> {
     fn new(
-        drop_func: &'ecx Body<'tcx>,
+        drop_instance: ty::Instance<'tcx>,
         drop_ty: Ty<'tcx>,
         ecx: &'ecx FSAEntryPointCtxt<'tcx>,
     ) -> Self {
-        assert_eq!(drop_func.arg_count, 1);
-        let mut funcs = VecDeque::default();
-        funcs.push_back(drop_func);
-        Self { funcs, ecx, drop_ty, visited_fns: FxHashSet::default() }
+        let mut callsites = VecDeque::default();
+        callsites.push_back(drop_instance);
+        Self { callsites, ecx, drop_ty, visited_fns: FxHashSet::default() }
     }
 
     fn check(mut self) -> Result<(), Vec<FinalizerErrorKind<'tcx>>> {
         let mut errors = Vec::new();
         loop {
-            let Some(body) = self.funcs.pop_front() else {
+            let Some(instance) = self.callsites.pop_front() else {
                 break;
             };
-            match FuncCtxt::new(body, &mut self).check() {
+            if self.visited_fns.contains(&instance) {
+                // We've already checked this function. Ignore it!
+                continue;
+            }
+            self.visited_fns.insert(instance);
+
+            let Some(mir) = self.ecx.prefer_instantiated_mir(instance) else {
+                bug!();
+            };
+            match FuncCtxt::new(&mir, &mut self).check() {
                 Err(ref mut e) => errors.append(e),
                 _ => (),
             }
@@ -449,8 +466,15 @@ impl<'ecx, 'tcx> DropCtxt<'ecx, 'tcx> {
     }
 }
 
+struct FuncCtxt<'dcx, 'ecx, 'tcx> {
+    body: &'dcx Body<'tcx>,
+    dcx: &'dcx mut DropCtxt<'ecx, 'tcx>,
+    errors: Vec<FinalizerErrorKind<'tcx>>,
+    error_locs: FxHashSet<Location>,
+}
+
 impl<'dcx, 'ecx, 'tcx> FuncCtxt<'dcx, 'ecx, 'tcx> {
-    fn new(body: &'ecx Body<'tcx>, dcx: &'dcx mut DropCtxt<'ecx, 'tcx>) -> Self {
+    fn new(body: &'dcx Body<'tcx>, dcx: &'dcx mut DropCtxt<'ecx, 'tcx>) -> Self {
         Self { body, dcx, errors: Vec::new(), error_locs: FxHashSet::default() }
     }
 
@@ -531,21 +555,15 @@ impl<'dcx, 'ecx, 'tcx> Visitor<'tcx> for FuncCtxt<'dcx, 'ecx, 'tcx> {
             self.super_terminator(terminator, location);
             return;
         };
+        let fn_info = FnInfo::new(*fn_span, self.dcx.drop_ty);
         match ty::Instance::resolve(self.tcx(), self.ecx().param_env, *fn_did, substs) {
             Ok(Some(instance)) => {
-                let mono_fn_did = instance.def.def_id();
-                if self.dcx.visited_fns.contains(&mono_fn_did) {
-                    // We've already checked this function. Ignore it!
+                if !self.tcx().is_mir_available(instance.def_id()) {
+                    self.push_error(location, FinalizerErrorKind::MissingFnDef(fn_info));
                     self.super_terminator(terminator, location);
                     return;
                 }
-                self.dcx.visited_fns.insert(mono_fn_did);
-                if self.tcx().is_mir_available(mono_fn_did) {
-                    self.dcx.funcs.push_back(self.tcx().instance_mir(instance.def));
-                } else {
-                    let fn_info = FnInfo::new(*fn_span, self.dcx.drop_ty);
-                    self.push_error(location, FinalizerErrorKind::MissingFnDef(fn_info))
-                }
+                self.dcx.callsites.push_back(instance);
             }
             Ok(None) => {
                 let fn_info = FnInfo::new(*fn_span, self.dcx.drop_ty);

--- a/tests/ui/static/gc/fsa/auxiliary/types.rs
+++ b/tests/ui/static/gc/fsa/auxiliary/types.rs
@@ -77,5 +77,15 @@ impl<'a> std::default::Default for HasNestedGc {
 struct Wrapper<T: Debug>(T);
 
 #[derive(Debug)]
-struct NotFinalizerSafe(u8);
-impl !FinalizerSafe for NotFinalizerSafe {}
+struct U8Wrapper(u8);
+
+#[derive(Debug)]
+struct FinalizerUnsafeU8Wrapper(u8);
+impl !FinalizerSafe for FinalizerUnsafeU8Wrapper {}
+
+#[derive(Debug)]
+struct FinalizerUnsafeWrapper<T: Debug>(T);
+impl<T> !FinalizerSafe for FinalizerUnsafeWrapper<T> {}
+
+#[derive(Debug)]
+struct FinalizerUnsafeType(u8);

--- a/tests/ui/static/gc/fsa/basic_calls.rs
+++ b/tests/ui/static/gc/fsa/basic_calls.rs
@@ -29,7 +29,9 @@ fn baz<T: Debug>(x: &Wrapper<T>) {
 }
 
 fn main() {
-    Gc::new(Wrapper(NotFinalizerSafe(1)));
-    //~^   ERROR: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
-    //~^^  ERROR: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
+    Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
+    //~^ ERROR: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
+    //~| ERROR: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
+
+    Gc::new(Wrapper(Wrapper(1)));
 }

--- a/tests/ui/static/gc/fsa/basic_calls.stderr
+++ b/tests/ui/static/gc/fsa/basic_calls.stderr
@@ -1,32 +1,32 @@
-error: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
+error: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
   --> $DIR/basic_calls.rs:32:13
    |
 LL |     use_val(&x.0); // should fail
    |             ----
    |             |
-   |             a finalizer cannot safely use this `T`
-   |             from a drop method because it does not implement `Send` + `Sync`.
+   |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
+   |             from a drop method because it does not implement `FinalizerSafe`.
 ...
-LL |     Gc::new(Wrapper(NotFinalizerSafe(1)));
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<NotFinalizerSafe>>` here.
+LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values which are thread-safe.
+           must only use values whose types implement `FinalizerSafe`.
 
-error: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
+error: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
   --> $DIR/basic_calls.rs:32:13
    |
 LL |     use_val(&x.0); // should fail
    |             ----
    |             |
-   |             a finalizer cannot safely use this `T`
-   |             from a drop method because it does not implement `Send` + `Sync`.
+   |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
+   |             from a drop method because it does not implement `FinalizerSafe`.
 ...
-LL |     Gc::new(Wrapper(NotFinalizerSafe(1)));
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<NotFinalizerSafe>>` here.
+LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values which are thread-safe.
+           must only use values whose types implement `FinalizerSafe`.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/gc/fsa/drop_glue.rs
+++ b/tests/ui/static/gc/fsa/drop_glue.rs
@@ -1,0 +1,22 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+impl<T: Debug> Drop for Wrapper<T> {
+    fn drop(&mut self) {
+        use_val(&self.0);
+    }
+}
+
+impl<T: Debug> Drop for FinalizerUnsafeWrapper<T> {
+    fn drop(&mut self) {
+        use_val(&self.0);
+    }
+}
+
+fn main() {
+    Gc::new(Wrapper(FinalizerUnsafeWrapper(FinalizerUnsafeWrapper(FinalizerUnsafeType(1)))));
+    //~^ ERROR: The drop method for `Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>` cannot be safely finalized.
+    //~| ERROR: The drop method for `FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>` cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/drop_glue.stderr
+++ b/tests/ui/static/gc/fsa/drop_glue.stderr
@@ -1,0 +1,32 @@
+error: The drop method for `Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>` cannot be safely finalized.
+  --> $DIR/drop_glue.rs:19:13
+   |
+LL |         use_val(&self.0);
+   |                 -------
+   |                 |
+   |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>`
+   |                 from a drop method because it does not implement `FinalizerSafe`.
+...
+LL |     Gc::new(Wrapper(FinalizerUnsafeWrapper(FinalizerUnsafeWrapper(FinalizerUnsafeType(1)))));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>>` here.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: The drop method for `FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>` cannot be safely finalized.
+  --> $DIR/drop_glue.rs:19:13
+   |
+LL |         use_val(&self.0);
+   |                 -------
+   |                 |
+   |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<FinalizerUnsafeType>`
+   |                 from a drop method because it does not implement `FinalizerSafe`.
+...
+LL |     Gc::new(Wrapper(FinalizerUnsafeWrapper(FinalizerUnsafeWrapper(FinalizerUnsafeType(1)))));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>>` here.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/static/gc/fsa/monomorphization.rs
+++ b/tests/ui/static/gc/fsa/monomorphization.rs
@@ -1,0 +1,67 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+impl<T: Debug> Drop for Wrapper<T> {
+    fn drop(&mut self) {
+        foo(&self);
+        use_val(&self.0);
+    }
+}
+
+fn foo<T: Debug>(val: T) {
+    use_val(val);
+}
+
+impl Drop for U8Wrapper {
+    fn drop(&mut self) {
+        use_val(self.0);
+        bar(&self);
+    }
+}
+
+#[derive(Debug)]
+struct S(FinalizerUnsafeU8Wrapper);
+
+impl Drop for S {
+    fn drop(&mut self) {
+        use_val(&self);
+        baz(&self.0);
+    }
+}
+
+fn bar(val: &U8Wrapper) {
+    use_val(val.0);
+}
+
+fn baz(val: &FinalizerUnsafeU8Wrapper) {
+    use_val(val.0);
+}
+
+
+fn main() {
+    // Test that we can use the monomorphized MIR for `Wrapper<T>::drop`.
+
+    // This should pass, because the monomorphized drop is `Wrapper<Wrapper<u8>>::drop` and
+    // implements `Send` + `Sync` + `FinalizerSafe`.
+    //
+    // This will fail if FSA can't obtain the monomorphized drop method, as FSA can't know if the
+    // `T` in `Wrapper<T>::drop` implements `Send` + `Sync` + `FinalizerSafe`. Since the generic
+    // substitutions are available, that would be a bug.
+    let _: Gc<Wrapper<Wrapper<u8>>> = Gc::new(Wrapper(Wrapper(1)));
+
+    // This should fail, but only for `FinalizerSafe` because
+    // `Wrapper<FinalizerUnsafeWrapper<u8>>::drop` implements `Send` + `Sync` but not
+    // `FinalizerSafe`. If monomorphization fails, we will get a `NotSendAndSync` error which would
+    // be incorrect.
+    let _: Gc<Wrapper<FinalizerUnsafeWrapper<u8>>> = Gc::new(Wrapper(FinalizerUnsafeWrapper(1)));
+    //~^ ERROR: The drop method for `Wrapper<FinalizerUnsafeWrapper<u8>>` cannot be safely finalized.
+
+    // Test that trying to monomorphize MIR doesn't break non-generic drops.
+
+    Gc::new(U8Wrapper(1));
+
+    Gc::new(S(FinalizerUnsafeU8Wrapper(1)));
+    //~^ ERROR: The drop method for `S` cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/monomorphization.stderr
+++ b/tests/ui/static/gc/fsa/monomorphization.stderr
@@ -1,0 +1,32 @@
+error: The drop method for `Wrapper<FinalizerUnsafeWrapper<u8>>` cannot be safely finalized.
+  --> $DIR/monomorphization.rs:58:62
+   |
+LL |         use_val(&self.0);
+   |                 -------
+   |                 |
+   |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<u8>`
+   |                 from a drop method because it does not implement `FinalizerSafe`.
+...
+LL |     let _: Gc<Wrapper<FinalizerUnsafeWrapper<u8>>> = Gc::new(Wrapper(FinalizerUnsafeWrapper(1)));
+   |                                                      --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<u8>>>` here.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: The drop method for `S` cannot be safely finalized.
+  --> $DIR/monomorphization.rs:65:13
+   |
+LL |         baz(&self.0);
+   |             -------
+   |             |
+   |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
+   |             from a drop method because it does not implement `FinalizerSafe`.
+...
+LL |     Gc::new(S(FinalizerUnsafeU8Wrapper(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<S>` here.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `FinalizerSafe`.
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/static/gc/fsa/recursive_calls.rs
+++ b/tests/ui/static/gc/fsa/recursive_calls.rs
@@ -28,6 +28,8 @@ fn fsa_safe<T: Debug>(x: &Wrapper<T>, recurse: bool) {
 }
 
 fn main() {
-    Gc::new(Wrapper(NotFinalizerSafe(1)));
-    //~^   ERROR: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
+    Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
+    //~^   ERROR: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
+
+    Gc::new(Wrapper(Wrapper(1)));
 }

--- a/tests/ui/static/gc/fsa/recursive_calls.stderr
+++ b/tests/ui/static/gc/fsa/recursive_calls.stderr
@@ -1,17 +1,17 @@
-error: The drop method for `Wrapper<NotFinalizerSafe>` cannot be safely finalized.
+error: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
   --> $DIR/recursive_calls.rs:31:13
    |
 LL |     use_val(&x.0); // should fail
    |             ----
    |             |
-   |             a finalizer cannot safely use this `T`
-   |             from a drop method because it does not implement `Send` + `Sync`.
+   |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
+   |             from a drop method because it does not implement `FinalizerSafe`.
 ...
-LL |     Gc::new(Wrapper(NotFinalizerSafe(1)));
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<NotFinalizerSafe>>` here.
+LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values which are thread-safe.
+           must only use values whose types implement `FinalizerSafe`.
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/gc/fsa/stdlib_errors.stderr
+++ b/tests/ui/static/gc/fsa/stdlib_errors.stderr
@@ -1,12 +1,11 @@
 error: The drop method for `Rc<u8>` cannot be safely finalized.
   --> $DIR/stdlib_errors.rs:31:13
    |
-LL |       Gc::new(s);
-   |       --------^- caused by trying to construct a `Gc<S>` here.
-  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
-   |
-   = note: is not safe to be run as a finalizer
+LL |     Gc::new(s);
+   |     --------^-
+   |     |       |
+   |     |       this `Rc<u8>` is not safe to be run as a finalizer
+   |     caused by trying to construct a `Gc<S>` here.
 
 error: The drop method for `T` cannot be safely finalized.
   --> $DIR/stdlib_errors.rs:34:13
@@ -26,22 +25,20 @@ LL |     Gc::new(t);
 error: The drop method for `Rc<u8>` cannot be safely finalized.
   --> $DIR/stdlib_errors.rs:34:13
    |
-LL |       Gc::new(t);
-   |       --------^- caused by trying to construct a `Gc<T>` here.
-  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
-   |
-   = note: is not safe to be run as a finalizer
+LL |     Gc::new(t);
+   |     --------^-
+   |     |       |
+   |     |       this `Rc<u8>` is not safe to be run as a finalizer
+   |     caused by trying to construct a `Gc<T>` here.
 
 error: The drop method for `Rc<Rc<Rc<u8>>>` cannot be safely finalized.
   --> $DIR/stdlib_errors.rs:38:13
    |
-LL |       Gc::new(u);
-   |       --------^- caused by trying to construct a `Gc<U>` here.
-  --> $SRC_DIR/alloc/src/rc.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/rc.rs:LL:COL
-   |
-   = note: is not safe to be run as a finalizer
+LL |     Gc::new(u);
+   |     --------^-
+   |     |       |
+   |     |       this `Rc<Rc<Rc<u8>>>` is not safe to be run as a finalizer
+   |     caused by trying to construct a `Gc<U>` here.
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Previously, if FSA encountered a function (i.e. a drop method, or one
its callsites) which had a type parameter, we would only obtain the
polymorphic MIR for that function. In other words, when FSA checked over
a function, it would check the concrete implementations of that
function. This meant that any uses of type parameters inside that
function would cause an FSA error, because it could never know if it was
safe. For example:

```
fn foo<T>(x: T) {
    use(x)
}
```

If `foo` was used inside a drop method, this would always emit an error,
because FSA would not know whether `T: Send + Sync + FinalizerSafe`.

This commit fixes this by attempting to load the monomorphized MIR for a
function if it is available. Where it's not available, we fallback to
checking a function's polymorphic MIR.