### PR TITLE
Fix soundness hole in FSA due to nested drops

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -376,7 +376,7 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                     self.arg_span,
                     format!("The drop method for `{0}` cannot be safely finalized.", fi.drop_ty),
                 );
-                err.span_label(self.arg_span, "contains a function call which may be unsafe.");
+                err.span_label(fi.span, "this function call may be unsafe to use in a finalizer.");
             }
             FinalizerErrorKind::UnknownTraitObject(fi) => {
                 err = self.tcx.sess.psess.dcx.struct_span_err(
@@ -546,30 +546,80 @@ impl<'dcx, 'ecx, 'tcx> Visitor<'tcx> for FuncCtxt<'dcx, 'ecx, 'tcx> {
     }
 
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
-        let TerminatorKind::Call { func, fn_span, .. } = &terminator.kind else {
-            self.super_terminator(terminator, location);
-            return;
-        };
-        let fn_ty = func.ty(self.body, self.tcx());
-        let ty::FnDef(fn_did, substs) = fn_ty.kind() else {
-            self.super_terminator(terminator, location);
-            return;
-        };
-        let fn_info = FnInfo::new(*fn_span, self.dcx.drop_ty);
-        match ty::Instance::resolve(self.tcx(), self.ecx().param_env, *fn_did, substs) {
-            Ok(Some(instance)) => {
-                if !self.tcx().is_mir_available(instance.def_id()) {
-                    self.push_error(location, FinalizerErrorKind::MissingFnDef(fn_info));
+        let (instance, info) = match &terminator.kind {
+            TerminatorKind::Call { func, fn_span, .. } => {
+                match func.ty(self.body, self.tcx()).kind() {
+                    ty::FnDef(fn_did, substs) => {
+                        let info = FnInfo::new(*fn_span, self.dcx.drop_ty);
+                        let Ok(instance) = ty::Instance::resolve(
+                            self.tcx(),
+                            self.ecx().param_env,
+                            *fn_did,
+                            substs,
+                        ) else {
+                            bug!();
+                        };
+                        (instance, info)
+                    }
+                    ty::FnPtr(..) => {
+                        // FSA doesn't support function pointers so this will trigger an error down
+                        // the line.
+                        let span = terminator.source_info.span;
+                        let info = FnInfo::new(span, self.dcx.drop_ty);
+                        (None, info)
+                    }
+                    _ => bug!(),
+                }
+            }
+            TerminatorKind::Drop { place, .. } => {
+                let glue_ty = place.ty(self.body, self.tcx()).ty;
+                let glue = ty::Instance::resolve_drop_in_place(self.tcx(), glue_ty);
+                let ty::InstanceDef::DropGlue(_, ty) = glue.def else {
+                    bug!();
+                };
+
+                if ty.is_none()
+                    || ty.unwrap().ty_adt_def().map_or(true, |adt| !adt.has_dtor(self.tcx()))
+                    || ty.unwrap().is_gc(self.tcx())
+                {
+                    // This check is necessary because FSA happens before optimisation passes like
+                    // 'drop elaboration', so the MIR might contain drop terminators for types that
+                    // don't actually have a drop method.
+                    //
+                    // In addition, we only care if the *top level* part of this type has a drop
+                    // method. If any of its fields also require dropping then they will have
+                    // separate MIR terminators because drop glue will have added them.
+                    //
+                    // We also have to check for, and ignore `Gc<T>`'s, because they have a
+                    // destructor for the premature finalization barriers. This is FSA safe though.
                     self.super_terminator(terminator, location);
                     return;
                 }
+                let drop_trait_did = self.tcx().require_lang_item(LangItem::Drop, None);
+                let poly_drop_fn_did = self.tcx().associated_item_def_ids(drop_trait_did)[0];
+                let Ok(instance) = ty::Instance::resolve(
+                    self.tcx(),
+                    self.ecx().param_env,
+                    poly_drop_fn_did,
+                    self.tcx().mk_args(&[ty.unwrap().into()]),
+                ) else {
+                    bug!();
+                };
+                let span = terminator.source_info.span;
+                let info = FnInfo::new(span, self.dcx.drop_ty);
+                (instance, info)
+            }
+            _ => {
+                self.super_terminator(terminator, location);
+                return;
+            }
+        };
+
+        match instance {
+            Some(instance) if self.tcx().is_mir_available(instance.def_id()) => {
                 self.dcx.callsites.push_back(instance);
             }
-            Ok(None) => {
-                let fn_info = FnInfo::new(*fn_span, self.dcx.drop_ty);
-                self.push_error(location, FinalizerErrorKind::MissingFnDef(fn_info))
-            }
-            Err(_) => bug!(),
+            _ => self.push_error(location, FinalizerErrorKind::MissingFnDef(info)),
         };
         self.super_terminator(terminator, location);
     }

--- a/tests/ui/static/gc/fsa/inline_asm.rs
+++ b/tests/ui/static/gc/fsa/inline_asm.rs
@@ -1,0 +1,33 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![feature(rustc_private)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+include!{"./auxiliary/types.rs"}
+
+use std::arch::asm;
+
+#[derive(Debug)]
+struct ASM;
+
+impl Drop for ASM {
+    fn drop(&mut self) {
+        let a: u64 = 10;
+        let b: u64 = 20;
+        let result: u64;
+        unsafe {
+            asm!(
+                "add {0}, {1}, {2}",
+                out(reg) result,
+                in(reg) a,
+                in(reg) b
+            );
+        }
+    }
+}
+
+
+fn main() {
+    Gc::new(FinalizerUnsafeWrapper(ASM));
+    //~^ ERROR: The drop method for `ASM` cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/inline_asm.stderr
+++ b/tests/ui/static/gc/fsa/inline_asm.stderr
@@ -1,0 +1,16 @@
+error: The drop method for `ASM` cannot be safely finalized.
+  --> $DIR/inline_asm.rs:31:13
+   |
+LL | /             asm!(
+LL | |                 "add {0}, {1}, {2}",
+LL | |                 out(reg) result,
+LL | |                 in(reg) a,
+LL | |                 in(reg) b
+LL | |             );
+   | |_____________- this assembly block is not safe to run in a finalizer
+...
+LL |       Gc::new(FinalizerUnsafeWrapper(ASM));
+   |       --------^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<FinalizerUnsafeWrapper<ASM>>` here.
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/static/gc/fsa/nested_drops.rs
+++ b/tests/ui/static/gc/fsa/nested_drops.rs
@@ -1,0 +1,53 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![feature(rustc_private)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+include!{"./auxiliary/types.rs"}
+
+
+extern crate libc;
+
+struct HasSafeDrop;
+struct HasUnsafeDrop1;
+struct HasUnsafeDrop2;
+
+impl Drop for HasSafeDrop { fn drop(&mut self) { let x = 1;} }
+
+impl Drop for HasUnsafeDrop1 {
+    fn drop(&mut self) {
+        unsafe { libc::malloc(8) as *mut i32 };
+        foo();
+    }
+}
+
+impl Drop for HasUnsafeDrop2 {
+    fn drop(&mut self) {
+        unsafe { libc::calloc(8, 8) as *mut i32 };
+    }
+}
+
+fn foo() {
+    let s = HasUnsafeDrop2;
+}
+
+#[derive(Debug)]
+struct HasUnsafeNestedDrop(u8);
+#[derive(Debug)]
+struct HasSafeNestedDrop(u8);
+
+impl Drop for HasUnsafeNestedDrop  {
+    fn drop(&mut self) { let s = HasUnsafeDrop1; }
+}
+
+impl Drop for HasSafeNestedDrop  {
+    fn drop(&mut self) { let s = HasSafeDrop; }
+}
+
+fn main() {
+    Gc::new(FinalizerUnsafeWrapper(HasUnsafeNestedDrop(1)));
+    //~^ ERROR: The drop method for `HasUnsafeNestedDrop` cannot be safely finalized.
+    //~| ERROR: The drop method for `HasUnsafeNestedDrop` cannot be safely finalized.
+
+    Gc::new(FinalizerUnsafeWrapper(HasSafeNestedDrop(1)));
+}

--- a/tests/ui/static/gc/fsa/nested_drops.stderr
+++ b/tests/ui/static/gc/fsa/nested_drops.stderr
@@ -1,0 +1,20 @@
+error: The drop method for `HasUnsafeNestedDrop` cannot be safely finalized.
+  --> $DIR/nested_drops.rs:48:13
+   |
+LL |         unsafe { libc::malloc(8) as *mut i32 };
+   |                  --------------- this function call may be unsafe to use in a finalizer.
+...
+LL |     Gc::new(FinalizerUnsafeWrapper(HasUnsafeNestedDrop(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<FinalizerUnsafeWrapper<HasUnsafeNestedDrop>>` here.
+
+error: The drop method for `HasUnsafeNestedDrop` cannot be safely finalized.
+  --> $DIR/nested_drops.rs:48:13
+   |
+LL |         unsafe { libc::calloc(8, 8) as *mut i32 };
+   |                  ------------------ this function call may be unsafe to use in a finalizer.
+...
+LL |     Gc::new(FinalizerUnsafeWrapper(HasUnsafeNestedDrop(1)));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<FinalizerUnsafeWrapper<HasUnsafeNestedDrop>>` here.
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Imagine a `Gc<T>` where `T` has a finalizer. Up until now, a value `v` allocated locally inside `T::drop` could create a backdoor where non-finalizer-safe stuff can happen without FSA knowing about it. Consider the following example:

```rust
struct S { .. }

impl Drop for S {
    fn drop(&mut self) {
        unsound_external_fn_call(); // called from finalizer.
    }
}

struct T { .. }

impl Drop for T {
    fn drop(&mut self) {
        let s = S { .. };
    } // also calls 'S::drop' for the local 's'.
}

fn main() { Gc::new(T::new()) }
```

This program is unsound, but it would *not* be caught by FSA. By allowing the alloca of `s`, we have inadvertently run the unsound nested `S::drop` inside a finalizer without checking.

Note that my use of the term 'nested drops' here is distinct from drop glue. Drop glue (i.e. where the drop methods for fields of a type are automatically called too) works as intended.

This commit updates FSA to handle such nested drops. The approach is very similar to how we handle drop methods which contain functions calls. Using the same example from above, we know that the MIR for `T::drop` (the type being finalized) will contain a terminator to call `S::drop`, so after FSA has finished looking at `T::drop`, it will obtain and then check the (potentially monomorphized) MIR for `S::drop`.

This fix also works when `S` has drop glue, because that would mean that drop methods for any of `S`'s fields would also be added as terminators in the MIR for `T::drop`.

If at any stage, the MIR for S::drop is unavailable, then we emit an FSA error.