### PR TITLE
Make `FinalizerSafe` an internal only trait 

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -35,22 +35,6 @@ cd yksom
 # Annoying hack needed in order to build a non-workspace crate inside alloy.
 echo "[workspace]" >> Cargo.toml
 
-cargo +alloy test
-cargo +alloy test --release
-
-cargo +alloy run  -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-cargo +alloy run --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-
-cargo +alloy run --release -- --cp SOM/Smalltalk:lang_tests hello_world1
-
-cd SOM
-cargo +alloy run --release -- \
-  --cp Smalltalk:TestSuite:SomSom/src/compiler:SomSom/src/vm:SomSom/src/vmobjects:SomSom/src/interpreter:SomSom/src/primitives \
-  SomSom/tests/SomSomTests.som
-cargo +alloy run --release -- \
-  --cp Smalltalk:Examples/Benchmarks/GraphSearch \
-  Examples/Benchmarks/BenchmarkHarness.som GraphSearch 10 4
-
 # Build and test grmtools
 cd ../
 git clone https://github.com/softdevteam/grmtools

--- a/library/alloc/src/collections/btree/borrow.rs
+++ b/library/alloc/src/collections/btree/borrow.rs
@@ -18,7 +18,6 @@ pub struct DormantMutRef<'a, T> {
 
 unsafe impl<'a, T> Sync for DormantMutRef<'a, T> where &'a mut T: Sync {}
 unsafe impl<'a, T> Send for DormantMutRef<'a, T> where &'a mut T: Send {}
-unsafe impl<'a, T> FinalizerSafe for DormantMutRef<'a, T> where &'a mut T: FinalizerSafe {}
 
 impl<'a, T> DormantMutRef<'a, T> {
     /// Capture a unique borrow, and immediately reborrow it. For the compiler,

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -205,10 +205,6 @@ impl<'a, K: 'a, V: 'a, Type> Clone for NodeRef<marker::Immut<'a>, K, V, Type> {
 }
 
 unsafe impl<BorrowType, K: Sync, V: Sync, Type> Sync for NodeRef<BorrowType, K, V, Type> {}
-unsafe impl<BorrowType, K: FinalizerSafe, V: FinalizerSafe, Type> FinalizerSafe
-    for NodeRef<BorrowType, K, V, Type>
-{
-}
 
 unsafe impl<K: Sync, V: Sync, Type> Send for NodeRef<marker::Immut<'_>, K, V, Type> {}
 unsafe impl<K: Send, V: Send, Type> Send for NodeRef<marker::Mut<'_>, K, V, Type> {}

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -2203,17 +2203,11 @@ unsafe impl<T: Send, A: Allocator + Send> Send for LinkedList<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for LinkedList<T, A> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for LinkedList<T> {}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for Iter<'_, T> {}
-
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IterMut<'_, T> {}
@@ -2221,23 +2215,14 @@ unsafe impl<T: Send> Send for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for IterMut<'_, T> {}
-
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync, A: Allocator + Sync> Send for Cursor<'_, T, A> {}
 
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for Cursor<'_, T, A> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for Cursor<'_, T> {}
-
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Send, A: Allocator + Send> Send for CursorMut<'_, T, A> {}
 
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for CursorMut<'_, T, A> {}
-
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for CursorMut<'_, T> {}

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -89,8 +89,6 @@ impl<T: fmt::Debug, A: Allocator> fmt::Debug for Drain<'_, T, A> {
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for Drain<'_, T, A> {}
 #[stable(feature = "drain", since = "1.6.0")]
 unsafe impl<T: Send, A: Allocator + Send> Send for Drain<'_, T, A> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe, A: Allocator + FinalizerSafe> FinalizerSafe for Drain<'_, T, A> {}
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -332,9 +332,6 @@ pub struct Rc<
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> !Send for Rc<T, A> {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for Rc<T> {}
-
 // Note that this negative impl isn't strictly necessary for correctness,
 // as `Rc` transitively contains a `Cell`, which is itself `!Sync`.
 // However, given how important `Rc`'s `!Sync`-ness is,
@@ -2818,8 +2815,6 @@ pub struct Weak<
 impl<T: ?Sized, A: Allocator> !Send for Weak<T, A> {}
 #[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized, A: Allocator> !Sync for Weak<T, A> {}
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized, A: Allocator> !FinalizerSafe for Weak<T, A> {}
 
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> CoerceUnsized<Weak<U, A>> for Weak<T, A> {}

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2956,8 +2956,6 @@ impl fmt::Debug for Drain<'_> {
 unsafe impl Sync for Drain<'_> {}
 #[stable(feature = "drain", since = "1.6.0")]
 unsafe impl Send for Drain<'_> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl FinalizerSafe for Drain<'_> {}
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl Drop for Drain<'_> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -261,8 +261,6 @@ pub struct Arc<
 unsafe impl<T: ?Sized + Sync + Send, A: Allocator + Send> Send for Arc<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send, A: Allocator + Sync> Sync for Arc<T, A> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized + FinalizerSafe, A: Allocator> FinalizerSafe for Arc<T, A> {}
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized, A: Allocator + UnwindSafe> UnwindSafe for Arc<T, A> {}
@@ -380,7 +378,6 @@ fn arcinner_layout_for_value_layout(layout: Layout) -> Layout {
 
 unsafe impl<T: ?Sized + Sync + Send> Send for ArcInner<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for ArcInner<T> {}
-unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for ArcInner<T> {}
 
 impl<T> Arc<T> {
     /// Constructs a new `Arc<T>`.

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -193,8 +193,6 @@ impl<T, A: Allocator> AsRef<[T]> for IntoIter<T, A> {
 unsafe impl<T: Send, A: Allocator + Send> Send for IntoIter<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for IntoIter<T, A> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe, A: Allocator + FinalizerSafe> FinalizerSafe for IntoIter<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> Iterator for IntoIter<T, A> {

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -297,9 +297,6 @@ pub struct Cell<T: ?Sized> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for Cell<T> {}
-
 // Note that this negative impl isn't strictly necessary for correctness,
 // as `Cell` wraps `UnsafeCell`, which is itself `!Sync`.
 // However, given how important `Cell`'s `!Sync`-ness is,
@@ -1267,9 +1264,6 @@ unsafe impl<T: ?Sized> Send for RefCell<T> where T: Send {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for RefCell<T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for RefCell<T> {}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone> Clone for RefCell<T> {
     /// # Panics
@@ -2043,8 +2037,6 @@ pub struct UnsafeCell<T: ?Sized> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for UnsafeCell<T> {}
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified
@@ -2287,9 +2279,6 @@ pub struct SyncUnsafeCell<T: ?Sized> {
 
 #[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 unsafe impl<T: ?Sized + Sync> Sync for SyncUnsafeCell<T> {}
-
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for SyncUnsafeCell<T> {}
 
 #[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T> SyncUnsafeCell<T> {

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -56,9 +56,6 @@ unsafe impl Send for ResumeTy {}
 #[unstable(feature = "gen_future", issue = "50547")]
 unsafe impl Sync for ResumeTy {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl FinalizerSafe for ResumeTy {}
-
 #[lang = "get_context"]
 #[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -56,9 +56,7 @@ impl<T: ?Sized> DerefMut for NonFinalizable<T> {
 /// violations.
 ///
 /// However, where this is too strict -- and the user knows T::drop to be sound
-/// -- `FinalizeUnchecked` can be used to opt-out of FSA. This is preferable to
-/// implementing the `FinalizerSafe` trait for `T` as `FinalizeUnchecked`
-/// applies only to individual uses of `T`.
+/// -- `FinalizeUnchecked` can be used to opt-out of FSA.
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "FinalizeUnchecked")]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -88,4 +86,4 @@ impl<T: ?Sized> DerefMut for FinalizeUnchecked<T> {
 }
 
 #[cfg(not(bootstrap))]
-unsafe impl<T> FinalizerSafe for FinalizeUnchecked<T> {}
+unsafe impl<T> core::marker::FinalizerSafe for FinalizeUnchecked<T> {}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -619,11 +619,6 @@ pub unsafe auto trait FinalizerSafe {
 }
 
 #[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for *const T {}
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for *mut T {}
-
-#[unstable(feature = "gc", issue = "none")]
 impl<T: ?Sized> !FinalizerSafe for &T {}
 #[unstable(feature = "gc", issue = "none")]
 impl<T: ?Sized> !FinalizerSafe for &mut T {}

--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -10,10 +10,6 @@ pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 
-#[unstable(feature = "gc", issue = "none")]
-#[doc(no_inline)]
-pub use crate::marker::FinalizerSafe;
-
 // Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -244,7 +244,6 @@ impl<Dyn: ?Sized> DynMetadata<Dyn> {
 
 unsafe impl<Dyn: ?Sized> Send for DynMetadata<Dyn> {}
 unsafe impl<Dyn: ?Sized> Sync for DynMetadata<Dyn> {}
-unsafe impl<Dyn: ?Sized> FinalizerSafe for DynMetadata<Dyn> {}
 
 impl<Dyn: ?Sized> fmt::Debug for DynMetadata<Dyn> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -84,9 +84,6 @@ impl<T: ?Sized> !Send for NonNull<T> {}
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> !Sync for NonNull<T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for NonNull<T> {}
-
 impl<T: Sized> NonNull<T> {
     /// Creates a new `NonNull` that is dangling, but well-aligned.
     ///

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -50,9 +50,6 @@ pub struct Unique<T: ?Sized> {
 #[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe + ?Sized> FinalizerSafe for Unique<T> {}
-
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -83,8 +83,6 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 unsafe impl<T: Sync> Sync for Iter<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: Sync> FinalizerSafe for Iter<'_, T> {}
 
 impl<'a, T> Iter<'a, T> {
     #[inline]
@@ -208,8 +206,6 @@ impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IterMut<'_, T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for IterMut<'_, T> {}
 
 impl<'a, T> IterMut<'a, T> {
     #[inline]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -301,8 +301,6 @@ unsafe impl<T> Send for AtomicPtr<T> {}
 #[cfg(target_has_atomic_load_store = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Sync for AtomicPtr<T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T> FinalizerSafe for AtomicPtr<T> {}
 
 /// Atomic memory orderings
 ///
@@ -2173,9 +2171,6 @@ macro_rules! atomic_int {
         // Send is implicitly implemented.
         #[$stable]
         unsafe impl Sync for $atomic_type {}
-
-        #[unstable(feature = "gc", issue = "none")]
-        unsafe impl core::marker::FinalizerSafe for $atomic_type {}
 
         impl $atomic_type {
             /// Creates a new atomic integer.

--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -88,9 +88,6 @@ pub struct Exclusive<T: ?Sized> {
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 unsafe impl<T: ?Sized> Sync for Exclusive<T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized> FinalizerSafe for Exclusive<T> {}
-
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T: ?Sized> fmt::Debug for Exclusive<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -438,8 +438,6 @@ impl Unpin for Waker {}
 unsafe impl Send for Waker {}
 #[stable(feature = "futures_api", since = "1.36.0")]
 unsafe impl Sync for Waker {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl FinalizerSafe for Waker {}
 
 impl Waker {
     /// Wake up the task associated with this `Waker`.

--- a/library/proc_macro/src/bridge/buffer.rs
+++ b/library/proc_macro/src/bridge/buffer.rs
@@ -16,7 +16,6 @@ pub struct Buffer {
 
 unsafe impl Sync for Buffer {}
 unsafe impl Send for Buffer {}
-unsafe impl FinalizerSafe for Buffer {}
 
 impl Default for Buffer {
     #[inline]

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -189,7 +189,6 @@ struct Bridge<'a> {
 
 impl<'a> !Send for Bridge<'a> {}
 impl<'a> !Sync for Bridge<'a> {}
-impl<'a> !FinalizerSafe for Bridge<'a> {}
 
 #[allow(unsafe_code)]
 mod state {

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -21,7 +21,6 @@ pub struct Symbol(NonZero<u32>);
 
 impl !Send for Symbol {}
 impl !Sync for Symbol {}
-impl !FinalizerSafe for Symbol {}
 
 impl Symbol {
     /// Intern a new `Symbol`

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -35,7 +35,6 @@
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
 #![feature(strict_provenance)]
-#![feature(gc)]
 #![recursion_limit = "256"]
 #![allow(internal_features)]
 #![deny(ffi_unwind_calls)]
@@ -89,8 +88,6 @@ pub struct TokenStream(Option<bridge::client::TokenStream>);
 impl !Send for TokenStream {}
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Sync for TokenStream {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for TokenStream {}
 
 /// Error returned from `TokenStream::from_str`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
@@ -112,8 +109,6 @@ impl error::Error for LexError {}
 impl !Send for LexError {}
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Sync for LexError {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for LexError {}
 
 /// Error returned from `TokenStream::expand_expr`.
 #[unstable(feature = "proc_macro_expand", issue = "90765")]
@@ -136,9 +131,6 @@ impl !Send for ExpandError {}
 
 #[unstable(feature = "proc_macro_expand", issue = "90765")]
 impl !Sync for ExpandError {}
-
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for ExpandError {}
 
 impl TokenStream {
     /// Returns an empty `TokenStream` containing no token trees.
@@ -453,8 +445,7 @@ pub struct Span(bridge::client::Span);
 impl !Send for Span {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Span {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for Span {}
+
 macro_rules! diagnostic_method {
     ($name:ident, $level:expr) => {
         /// Creates a new `Diagnostic` with the given `message` at the span
@@ -688,8 +679,6 @@ pub enum TokenTree {
 impl !Send for TokenTree {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for TokenTree {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for TokenTree {}
 
 impl TokenTree {
     /// Returns the span of this tree, delegating to the `span` method of
@@ -808,8 +797,6 @@ pub struct Group(bridge::Group<bridge::client::TokenStream, bridge::client::Span
 impl !Send for Group {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Group {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for Group {}
 
 /// Describes how a sequence of token trees is delimited.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -953,8 +940,6 @@ pub struct Punct(bridge::Punct<bridge::client::Span>);
 impl !Send for Punct {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Punct {}
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for Punct {}
 
 /// Indicates whether a `Punct` token can join with the following token
 /// to form a multi-character operator.

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -152,9 +152,6 @@ pub struct BacktraceFrame {
     symbols: Vec<BacktraceSymbol>,
 }
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl FinalizerSafe for BacktraceFrame {}
-
 #[derive(Debug)]
 enum RawFrame {
     Actual(backtrace_rs::Frame),

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -845,9 +845,6 @@ impl !Send for Args {}
 #[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for Args {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for Args {}
-
 #[stable(feature = "env", since = "1.0.0")]
 impl Iterator for Args {
     type Item = String;
@@ -889,9 +886,6 @@ impl !Send for ArgsOs {}
 
 #[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for ArgsOs {}
-
-#[unstable(feature = "gc", issue = "none")]
-impl !FinalizerSafe for ArgsOs {}
 
 #[stable(feature = "env", since = "1.0.0")]
 impl Iterator for ArgsOs {

--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -238,7 +238,7 @@ unsafe impl<T: ?Sized + Sync + Send> Sync for Gc<T> {}
 //
 // FIXME: Make this conditional based on whether -DTOPOLOGICAL_FINALIZATION flag
 // is passed to the compiler.
-impl<T: ?Sized> !FinalizerSafe for Gc<T> {}
+impl<T: ?Sized> !core::marker::FinalizerSafe for Gc<T> {}
 
 #[unstable(feature = "gc", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Gc<U>> for Gc<T> {}

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -129,7 +129,6 @@ pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 // All the types `Repr` stores internally are Send + Sync, and so is it.
 unsafe impl Send for Repr {}
 unsafe impl Sync for Repr {}
-unsafe impl FinalizerSafe for Repr {}
 
 impl Repr {
     pub(super) fn new(dat: ErrorData<Box<Custom>>) -> Self {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1222,9 +1222,6 @@ unsafe impl<'a> Send for IoSliceMut<'a> {}
 #[stable(feature = "iovec_send_sync", since = "1.44.0")]
 unsafe impl<'a> Sync for IoSliceMut<'a> {}
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<'a> core::marker::FinalizerSafe for IoSliceMut<'a> {}
-
 #[stable(feature = "iovec", since = "1.36.0")]
 impl<'a> fmt::Debug for IoSliceMut<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1367,9 +1364,6 @@ unsafe impl<'a> Send for IoSlice<'a> {}
 
 #[stable(feature = "iovec_send_sync", since = "1.44.0")]
 unsafe impl<'a> Sync for IoSlice<'a> {}
-
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<'a> FinalizerSafe for IoSlice<'a> {}
 
 #[stable(feature = "iovec", since = "1.36.0")]
 impl<'a> fmt::Debug for IoSlice<'a> {

--- a/library/std/src/prelude/common.rs
+++ b/library/std/src/prelude/common.rs
@@ -10,10 +10,6 @@ pub use crate::marker::{Send, Sized, Sync, Unpin};
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 
-#[unstable(feature = "gc", issue = "none")]
-#[doc(no_inline)]
-pub use crate::marker::FinalizerSafe;
-
 // Re-exported functions
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -246,9 +246,6 @@ impl<T: fmt::Debug, F> fmt::Debug for LazyLock<T, F> {
 unsafe impl<T: Sync + Send, F: Send> Sync for LazyLock<T, F> {}
 // auto-derived `Send` impl is OK.
 
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T, F: FinalizerSafe> FinalizerSafe for LazyLock<T, F> {}
-
 #[unstable(feature = "lazy_cell", issue = "109736")]
 impl<T: RefUnwindSafe + UnwindSafe, F: UnwindSafe> RefUnwindSafe for LazyLock<T, F> {}
 #[unstable(feature = "lazy_cell", issue = "109736")]

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -193,9 +193,6 @@ unsafe impl<T: Send> Send for Receiver<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for Receiver<T> {}
 
-#[unstable(feature = "gc", issue = "none")]
-impl<T> !FinalizerSafe for Receiver<T> {}
-
 /// An iterator over messages on a [`Receiver`], created by [`iter`].
 ///
 /// This iterator will block whenever [`next`] is called,
@@ -351,9 +348,6 @@ unsafe impl<T: Send> Send for Sender<T> {}
 
 #[stable(feature = "mpsc_sender_sync", since = "1.72.0")]
 unsafe impl<T: Send> Sync for Sender<T> {}
-
-#[unstable(feature = "gc", issue = "none")]
-impl<T> !FinalizerSafe for Sender<T> {}
 
 /// The sending-half of Rust's synchronous [`sync_channel`] type.
 ///

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -187,8 +187,6 @@ pub struct Mutex<T: ?Sized> {
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for Mutex<T> {}
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
@@ -217,8 +215,6 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
 impl<T: ?Sized> !Send for MutexGuard<'_, T> {}
 #[stable(feature = "mutexguard", since = "1.19.0")]
 unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
-#[unstable(feature = "gc", issue = "none")]
-impl<T: ?Sized> !FinalizerSafe for MutexGuard<'_, T> {}
 
 /// An RAII mutex guard returned by `MutexGuard::map`, which can point to a
 /// subfield of the protected data. When this structure is dropped (falls out

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -498,8 +498,6 @@ impl<T> OnceLock<T> {
 unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
 #[stable(feature = "once_cell", since = "1.70.0")]
 unsafe impl<T: Send> Send for OnceLock<T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: FinalizerSafe> FinalizerSafe for OnceLock<T> {}
 
 #[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -90,8 +90,6 @@ pub struct RwLock<T: ?Sized> {
 unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for RwLock<T> {}
 
 /// RAII structure used to release the shared read access of a lock when
 /// dropped.
@@ -122,9 +120,6 @@ impl<T: ?Sized> !Send for RwLockReadGuard<'_, T> {}
 
 #[stable(feature = "rwlock_guard_sync", since = "1.23.0")]
 unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
-
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for RwLockReadGuard<'_, T> {}
 
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.

--- a/library/std/src/sys/pal/unix/args.rs
+++ b/library/std/src/sys/pal/unix/args.rs
@@ -25,7 +25,6 @@ pub struct Args {
 
 impl !Send for Args {}
 impl !Sync for Args {}
-impl !FinalizerSafe for Args {}
 
 impl fmt::Debug for Args {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -289,7 +289,6 @@ struct Dir(*mut libc::DIR);
 
 unsafe impl Send for Dir {}
 unsafe impl Sync for Dir {}
-unsafe impl FinalizerSafe for Dir {}
 
 #[cfg(any(
     target_os = "android",

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -581,7 +581,6 @@ impl fmt::Debug for Env {
 
 impl !Send for Env {}
 impl !Sync for Env {}
-impl !FinalizerSafe for Env {}
 
 impl Iterator for Env {
     type Item = (OsString, OsString);

--- a/library/std/src/sys/pal/unix/process/process_common.rs
+++ b/library/std/src/sys/pal/unix/process/process_common.rs
@@ -117,7 +117,6 @@ struct Argv(Vec<*const c_char>);
 // pointers to memory owned by `Command.args`
 unsafe impl Send for Argv {}
 unsafe impl Sync for Argv {}
-unsafe impl FinalizerSafe for Argv {}
 
 // passed back to std::process with the pipes connected to the child, if any
 // were requested

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -45,7 +45,6 @@ pub struct Thread {
 // a thread to be Send/Sync
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
-unsafe impl FinalizerSafe for Thread {}
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -166,7 +166,6 @@ impl Iterator for LookupHost {
 
 unsafe impl Sync for LookupHost {}
 unsafe impl Send for LookupHost {}
-unsafe impl FinalizerSafe for LookupHost {}
 
 impl Drop for LookupHost {
     fn drop(&mut self) {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1542,8 +1542,6 @@ struct Packet<'scope, T> {
 // `UnsafeCell` synchronized (by the `join()` boundary), and `ScopeData` is Sync.
 unsafe impl<'scope, T: Sync> Sync for Packet<'scope, T> {}
 
-unsafe impl<'scope, T: FinalizerSafe> FinalizerSafe for Packet<'scope, T> {}
-
 impl<'scope, T> Drop for Packet<'scope, T> {
     fn drop(&mut self) {
         // If this packet was for a thread that ran in a scope, the thread
@@ -1660,8 +1658,6 @@ pub struct JoinHandle<T>(JoinInner<'static, T>);
 unsafe impl<T> Send for JoinHandle<T> {}
 #[stable(feature = "joinhandle_impl_send_sync", since = "1.29.0")]
 unsafe impl<T> Sync for JoinHandle<T> {}
-#[unstable(feature = "gc", issue = "none")]
-unsafe impl<T> FinalizerSafe for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     /// Extracts a handle to the underlying thread.

--- a/tests/rustdoc/empty-section.rs
+++ b/tests/rustdoc/empty-section.rs
@@ -7,8 +7,8 @@ pub struct Foo;
 // @!hasraw - 'Auto Trait Implementations'
 impl !Send for Foo {}
 impl !Sync for Foo {}
+impl !std::marker::FinalizerSafe for Foo {}
 impl !std::marker::Freeze for Foo {}
-impl !FinalizerSafe for Foo {}
 impl !std::marker::Unpin for Foo {}
 impl !std::panic::RefUnwindSafe for Foo {}
 impl !std::panic::UnwindSafe for Foo {}

--- a/tests/ui/runtime/gc/unchecked_finalizer.rs
+++ b/tests/ui/runtime/gc/unchecked_finalizer.rs
@@ -17,8 +17,6 @@ impl Drop for UnsafeContainer {
     }
 }
 
-impl !FinalizerSafe for UnsafeContainer {}
-
 static FINALIZER_COUNT: AtomicUsize = AtomicUsize::new(0);
 static ALLOCATED_COUNT: usize = 10;
 static SLEEP_MAX: u64 = 8192; // in millis.

--- a/tests/ui/static/gc/fsa/auxiliary/types.rs
+++ b/tests/ui/static/gc/fsa/auxiliary/types.rs
@@ -81,11 +81,11 @@ struct U8Wrapper(u8);
 
 #[derive(Debug)]
 struct FinalizerUnsafeU8Wrapper(u8);
-impl !FinalizerSafe for FinalizerUnsafeU8Wrapper {}
+impl !Send for FinalizerUnsafeU8Wrapper {}
 
 #[derive(Debug)]
 struct FinalizerUnsafeWrapper<T: Debug>(T);
-impl<T> !FinalizerSafe for FinalizerUnsafeWrapper<T> {}
+impl<T> !Send for FinalizerUnsafeWrapper<T> {}
 
 #[derive(Debug)]
 struct FinalizerUnsafeType(u8);

--- a/tests/ui/static/gc/fsa/basic_calls.stderr
+++ b/tests/ui/static/gc/fsa/basic_calls.stderr
@@ -5,13 +5,13 @@ LL |     use_val(&x.0); // should fail
    |             ----
    |             |
    |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
-   |             from a drop method because it does not implement `FinalizerSafe`.
+   |             from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: The drop method for `Wrapper<FinalizerUnsafeU8Wrapper>` cannot be safely finalized.
   --> $DIR/basic_calls.rs:32:13
@@ -20,13 +20,13 @@ LL |     use_val(&x.0); // should fail
    |             ----
    |             |
    |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
-   |             from a drop method because it does not implement `FinalizerSafe`.
+   |             from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/gc/fsa/drop_glue.stderr
+++ b/tests/ui/static/gc/fsa/drop_glue.stderr
@@ -5,13 +5,13 @@ LL |         use_val(&self.0);
    |                 -------
    |                 |
    |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(Wrapper(FinalizerUnsafeWrapper(FinalizerUnsafeWrapper(FinalizerUnsafeType(1)))));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: The drop method for `FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>` cannot be safely finalized.
   --> $DIR/drop_glue.rs:19:13
@@ -20,13 +20,13 @@ LL |         use_val(&self.0);
    |                 -------
    |                 |
    |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<FinalizerUnsafeType>`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(Wrapper(FinalizerUnsafeWrapper(FinalizerUnsafeWrapper(FinalizerUnsafeType(1)))));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<FinalizerUnsafeWrapper<FinalizerUnsafeType>>>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/gc/fsa/gc_refs.rs
+++ b/tests/ui/static/gc/fsa/gc_refs.rs
@@ -20,8 +20,7 @@ impl Drop for HasGc {
 fn main() {
     Gc::new(HasGc::default());
     //~^     ERROR: The drop method for `HasGc` cannot be safely finalized.
-    //~^^    ERROR: The drop method for `HasGc` cannot be safely finalized.
-    //~^^^   ERROR: The drop method for `HasGc` cannot be safely finalized.
-    //~^^^^  ERROR: The drop method for `HasGc` cannot be safely finalized.
-    //~^^^^^ ERROR: The drop method for `HasGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasGc` cannot be safely finalized.
 }

--- a/tests/ui/static/gc/fsa/gc_refs.stderr
+++ b/tests/ui/static/gc/fsa/gc_refs.stderr
@@ -16,14 +16,11 @@ error: The drop method for `HasGc` cannot be safely finalized.
 LL |         use_val(self.c[0]); // should fail
    |                 ---------
    |                 |
-   |                 a finalizer cannot safely use this `[Gc<u64>; 2]`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 a finalizer cannot safely dereference this `Gc<u64>`
+   |                 from a drop method because it might have already been finalized.
 ...
 LL |     Gc::new(HasGc::default());
    |     --------^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasGc>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
 
 error: The drop method for `HasGc` cannot be safely finalized.
   --> $DIR/gc_refs.rs:21:13
@@ -40,21 +37,6 @@ LL |     Gc::new(HasGc::default());
 error: The drop method for `HasGc` cannot be safely finalized.
   --> $DIR/gc_refs.rs:21:13
    |
-LL |         let c = self.c;
-   |                 ------
-   |                 |
-   |                 a finalizer cannot safely use this `[Gc<u64>; 2]`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
-...
-LL |     Gc::new(HasGc::default());
-   |     --------^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasGc>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
-
-error: The drop method for `HasGc` cannot be safely finalized.
-  --> $DIR/gc_refs.rs:21:13
-   |
 LL |         use_val(c[1]); // should fail
    |                 ----
    |                 |
@@ -64,5 +46,5 @@ LL |         use_val(c[1]); // should fail
 LL |     Gc::new(HasGc::default());
    |     --------^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasGc>` here.
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/static/gc/fsa/gc_refs_nested.rs
+++ b/tests/ui/static/gc/fsa/gc_refs_nested.rs
@@ -28,8 +28,7 @@ impl Drop for HasNestedGc {
 fn main() {
     Gc::new(HasNestedGc::default());
     //~^     ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
-    //~^^    ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
-    //~^^^   ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
-    //~^^^^  ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
-    //~^^^^^ ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasNestedGc` cannot be safely finalized.
 }

--- a/tests/ui/static/gc/fsa/gc_refs_nested.stderr
+++ b/tests/ui/static/gc/fsa/gc_refs_nested.stderr
@@ -16,29 +16,11 @@ error: The drop method for `HasNestedGc` cannot be safely finalized.
 LL |         use_val(self.c.a); // should fail
    |                 --------
    |                 |
-   |                 a finalizer cannot safely use this `HasGc`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 a finalizer cannot safely dereference this `Gc<u64>`
+   |                 from a drop method because it might have already been finalized.
 ...
 LL |     Gc::new(HasNestedGc::default());
    |     --------^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasNestedGc>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
-
-error: The drop method for `HasNestedGc` cannot be safely finalized.
-  --> $DIR/gc_refs_nested.rs:29:13
-   |
-LL |         use_val(self.c.b); // should pass
-   |                 --------
-   |                 |
-   |                 a finalizer cannot safely use this `HasGc`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
-...
-LL |     Gc::new(HasNestedGc::default());
-   |     --------^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasNestedGc>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
 
 error: The drop method for `HasNestedGc` cannot be safely finalized.
   --> $DIR/gc_refs_nested.rs:29:13
@@ -64,5 +46,5 @@ LL |         let ca = self.a; // should fail
 LL |     Gc::new(HasNestedGc::default());
    |     --------^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasNestedGc>` here.
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/static/gc/fsa/monomorphization.stderr
+++ b/tests/ui/static/gc/fsa/monomorphization.stderr
@@ -5,13 +5,13 @@ LL |         use_val(&self.0);
    |                 -------
    |                 |
    |                 a finalizer cannot safely use this `FinalizerUnsafeWrapper<u8>`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     let _: Gc<Wrapper<FinalizerUnsafeWrapper<u8>>> = Gc::new(Wrapper(FinalizerUnsafeWrapper(1)));
    |                                                      --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeWrapper<u8>>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: The drop method for `S` cannot be safely finalized.
   --> $DIR/monomorphization.rs:65:13
@@ -20,13 +20,13 @@ LL |         baz(&self.0);
    |             -------
    |             |
    |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
-   |             from a drop method because it does not implement `FinalizerSafe`.
+   |             from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(S(FinalizerUnsafeU8Wrapper(1)));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<S>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/gc/fsa/recursive_calls.stderr
+++ b/tests/ui/static/gc/fsa/recursive_calls.stderr
@@ -5,13 +5,13 @@ LL |     use_val(&x.0); // should fail
    |             ----
    |             |
    |             a finalizer cannot safely use this `FinalizerUnsafeU8Wrapper`
-   |             from a drop method because it does not implement `FinalizerSafe`.
+   |             from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(Wrapper(FinalizerUnsafeU8Wrapper(1)));
    |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<Wrapper<FinalizerUnsafeU8Wrapper>>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/gc/fsa/references.rs
+++ b/tests/ui/static/gc/fsa/references.rs
@@ -24,8 +24,7 @@ impl<'a> Drop for HasRef<'a> {
 fn main() {
     Gc::new(HasRef::default());
     //~^     ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
-    //~^^    ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
-    //~^^^   ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
-    //~^^^^  ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
-    //~^^^^^ ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
+    //~|     ERROR: The drop method for `HasRef<'_>` cannot be safely finalized.
 }

--- a/tests/ui/static/gc/fsa/references.stderr
+++ b/tests/ui/static/gc/fsa/references.stderr
@@ -18,14 +18,13 @@ error: The drop method for `HasRef<'_>` cannot be safely finalized.
 LL |         use_val(self.c[0]); // should fail
    |                 ---------
    |                 |
-   |                 a finalizer cannot safely use this `[&u64; 2]`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
 ...
 LL |     Gc::new(HasRef::default());
    |     --------^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasRef<'_>>` here.
    |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
 
 error: The drop method for `HasRef<'_>` cannot be safely finalized.
   --> $DIR/references.rs:25:13
@@ -44,21 +43,6 @@ LL |     Gc::new(HasRef::default());
 error: The drop method for `HasRef<'_>` cannot be safely finalized.
   --> $DIR/references.rs:25:13
    |
-LL |         let c = self.c;
-   |                 ------
-   |                 |
-   |                 a finalizer cannot safely use this `[&u64; 2]`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
-...
-LL |     Gc::new(HasRef::default());
-   |     --------^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasRef<'_>>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
-
-error: The drop method for `HasRef<'_>` cannot be safely finalized.
-  --> $DIR/references.rs:25:13
-   |
 LL |         use_val(c[1]); // should fail
    |                 ----
    |                 |
@@ -70,5 +54,5 @@ LL |     Gc::new(HasRef::default());
    |
    = help: `Gc` may run finalizers after the valid lifetime of this reference.
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/static/gc/fsa/references_nested.rs
+++ b/tests/ui/static/gc/fsa/references_nested.rs
@@ -36,9 +36,8 @@ impl<'a> Drop for HasNestedRef<'a> {
 fn main() {
     Gc::new(HasNestedRef::default());
     //~^       ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-    //~^^      ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-    //~^^^     ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-    //~^^^^    ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-    //~^^^^^   ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-    //~^^^^^^  ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
+    //~|       ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
+    //~|       ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
+    //~|       ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
+    //~|       ERROR: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
 }

--- a/tests/ui/static/gc/fsa/references_nested.stderr
+++ b/tests/ui/static/gc/fsa/references_nested.stderr
@@ -18,29 +18,13 @@ error: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
 LL |         use_val(self.c.a); // should fail
    |                 --------
    |                 |
-   |                 a finalizer cannot safely use this `HasRef<'_>`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 a finalizer cannot safely dereference this `&u64`
+   |                 because it might not live long enough.
 ...
 LL |     Gc::new(HasNestedRef::default());
    |     --------^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasNestedRef<'_>>` here.
    |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
-
-error: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
-  --> $DIR/references_nested.rs:37:13
-   |
-LL |         use_val(self.c.b); // should pass
-   |                 --------
-   |                 |
-   |                 a finalizer cannot safely use this `HasRef<'_>`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
-...
-LL |     Gc::new(HasNestedRef::default());
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<HasNestedRef<'_>>` here.
-   |
-   = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+   = help: `Gc` may run finalizers after the valid lifetime of this reference.
 
 error: The drop method for `HasNestedRef<'_>` cannot be safely finalized.
   --> $DIR/references_nested.rs:37:13
@@ -84,5 +68,5 @@ LL |     Gc::new(HasNestedRef::default());
    |
    = help: `Gc` may run finalizers after the valid lifetime of this reference.
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/static/gc/fsa/stdlib_errors.rs
+++ b/tests/ui/static/gc/fsa/stdlib_errors.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 struct S(Rc<u8>);
 
 struct Unsafe(u8);
-impl !FinalizerSafe for Unsafe {}
+impl !Send for Unsafe {}
 
 // Make sure that FSA still reports an error for the `Unsafe` field.
 struct T(S, Unsafe);

--- a/tests/ui/static/gc/fsa/stdlib_errors.stderr
+++ b/tests/ui/static/gc/fsa/stdlib_errors.stderr
@@ -14,13 +14,13 @@ LL |         let x = self.1.0; // should fail
    |                 --------
    |                 |
    |                 a finalizer cannot safely use this `Unsafe`
-   |                 from a drop method because it does not implement `FinalizerSafe`.
+   |                 from a drop method because it does not implement `Send` + `Sync`.
 ...
 LL |     Gc::new(t);
    |     --------^- caused by trying to construct a `Gc<T>` here.
    |
    = help: `Gc` runs finalizers on a separate thread, so drop methods
-           must only use values whose types implement `FinalizerSafe`.
+           must only use values which are thread-safe.
 
 error: The drop method for `Rc<u8>` cannot be safely finalized.
   --> $DIR/stdlib_errors.rs:34:13


### PR DESCRIPTION
This PR removes `FinalizerSafe` as a user implementable trait and instead re-purposes it so that it can make FSA easier by identifying types with references in their fields. 

This has breaking changes for yksom, so I've temporarily disabled it from CI and will re-enable it once this lands.