### PR TITLE
Emit FSA error for unions with manually drop fields

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -24,6 +24,8 @@ enum FinalizerErrorKind<'tcx> {
     UnsoundReference(FnInfo<'tcx>, ProjInfo<'tcx>),
     /// Uses a trait object whose concrete type is unknown
     UnknownTraitObject(FnInfo<'tcx>),
+    /// Uses a union with a drop method.
+    Union(FnInfo<'tcx>),
     /// Calls a function whose definition is unavailable, so we can't be certain it's safe.
     MissingFnDef(FnInfo<'tcx>),
     /// The drop glue contains an unsound drop method from an external crate. This will have been
@@ -219,6 +221,9 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                         tys.push(f)
                     }
                 }
+                ty::Adt(def, ..) if def.is_union() && def.has_dtor(self.tcx) => {
+                    errors.push(FinalizerErrorKind::Union(FnInfo::new(rustc_span::DUMMY_SP, ty)));
+                }
                 ty::Adt(def, substs) if !ty.is_copy_modulo_regions(self.tcx, self.param_env) => {
                     if def.is_box() {
                         // This is a special case because Box has an empty drop
@@ -250,6 +255,11 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                             Err(ref mut e) => errors.append(e),
                             _ => (),
                         }
+                    }
+                    if def.is_union() {
+                        // By definition, a union's fields can never have drop glue, so we don't need
+                        // to add them.
+                        continue;
                     }
 
                     for field in def.all_fields() {
@@ -388,6 +398,16 @@ impl<'tcx> FSAEntryPointCtxt<'tcx> {
                 err.span_label(
                     self.arg_span,
                     "contains a trait object whose implementation is unknown.",
+                );
+            }
+            FinalizerErrorKind::Union(fi) => {
+                err = self.tcx.sess.psess.dcx.struct_span_err(
+                    self.arg_span,
+                    format!("The drop method for `{0}` cannot be safely finalized.", fi.drop_ty),
+                );
+                err.span_label(
+                    self.arg_span,
+                    "contains a union whose drop glue cannot be known at compile-time.",
                 );
             }
             FinalizerErrorKind::UnsoundExternalDropGlue(fi) => {

--- a/tests/ui/static/gc/fsa/unions.rs
+++ b/tests/ui/static/gc/fsa/unions.rs
@@ -1,0 +1,43 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![feature(rustc_private)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use std::gc::Gc;
+use std::mem::ManuallyDrop;
+
+struct S(u8);
+struct T(u8);
+
+impl Drop for S {
+    fn drop(&mut self) {
+    }
+}
+
+
+impl Drop for T {
+    fn drop(&mut self) {
+    }
+}
+
+union U {
+    a: ManuallyDrop<S>,
+    b: ManuallyDrop<T>,
+}
+
+impl Drop for U {
+    fn drop(&mut self) {
+        let x = unsafe  { &self.a };
+    }
+}
+
+impl !Send for U {}
+impl !Send for S {}
+impl !Send for T {}
+
+fn main() {
+    let u = U { a: ManuallyDrop::new(S(1)) };
+    Gc::new(u);
+    //~^ ERROR: The drop method for `U` cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/unions.stderr
+++ b/tests/ui/static/gc/fsa/unions.stderr
@@ -1,0 +1,11 @@
+error: The drop method for `U` cannot be safely finalized.
+  --> $DIR/unions.rs:41:13
+   |
+LL |     Gc::new(u);
+   |     --------^-
+   |     |       |
+   |     |       contains a union whose drop glue cannot be known at compile-time.
+   |     caused by trying to construct a `Gc<U>` here.
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
For reasons that are not quite clear to me, trying to monomorphize a manually droppable union field causes an internal compile error in rustc. I think for now the best way to deal with this is to throw an error and require the user to manually mark such types as finalizer safe or not depending on their use-case.

Ideally we could improve on this at a later date as there is no reason in theory why we shouldn't be able to support union types.