### PR TITLE
Use FSA to check for thread-locals

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1224,6 +1224,13 @@ impl<'tcx> Ty<'tcx> {
         return false;
     }
 
+    pub fn is_thread_local(self, tcx: TyCtxt<'tcx>) -> bool {
+        if let ty::Adt(adt_def, ..) = self.kind() {
+            return tcx.get_diagnostic_item(sym::LocalKey).map_or(false, |t| adt_def.did() == t);
+        }
+        false
+    }
+
     pub fn is_finalize_unchecked(self, tcx: TyCtxt<'tcx>) -> bool {
         if let ty::Adt(adt_def, ..) = self.kind() {
             return tcx

--- a/tests/ui/static/gc/fsa/thread_locals.rs
+++ b/tests/ui/static/gc/fsa/thread_locals.rs
@@ -1,0 +1,27 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+include!{"./auxiliary/types.rs"}
+
+use std::cell::Cell;
+
+thread_local! {
+    static COUNTER: Cell<u32> = Cell::new(0);
+}
+
+
+#[derive(Debug)]
+struct S;
+
+impl Drop for S {
+    fn drop(&mut self) {
+        // Access the thread-local variable
+        let x = COUNTER.get();
+    }
+}
+
+fn main() {
+    Gc::new(FinalizerUnsafeWrapper(S));
+    //~^ ERROR: The drop method for `S` cannot be safely finalized.
+}

--- a/tests/ui/static/gc/fsa/thread_locals.stderr
+++ b/tests/ui/static/gc/fsa/thread_locals.stderr
@@ -1,0 +1,13 @@
+error: The drop method for `S` cannot be safely finalized.
+  --> $DIR/thread_locals.rs:25:13
+   |
+LL |         let x = COUNTER.get();
+   |                 ------- this thread-local is not safe to run in a finalizer
+...
+LL |     Gc::new(FinalizerUnsafeWrapper(S));
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^- caused by trying to construct a `Gc<FinalizerUnsafeWrapper<S>>` here.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so thread-locals cannot be accessed.
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Finalizers in Alloy are run on a separate thread, so if a user tries to access a thread-local from within a drop method used as a finalizer it is almost certainly incorrect. This commit disallows this and emit an error when it happens.