### PR TITLE
Ensure that [alloy] opts in `config.toml` are always applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,8 @@ dependencies = [
  "rustc_codegen_ssa",
  "rustc_driver",
  "rustc_driver_impl",
+ "rustc_middle",
+ "rustc_mir_transform",
  "rustc_smir",
  "stable_mir",
 ]

--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -20,6 +20,8 @@ rustc_smir = { path = "../rustc_smir" }
 stable_mir = { path = "../stable_mir" }
 # tidy-alphabetical-end
 
+rustc_mir_transform = { path = "../rustc_mir_transform" }
+rustc_middle = { path = "../rustc_middle" }
 [dependencies.jemalloc-sys]
 version = "0.5.0"
 optional = true
@@ -32,3 +34,7 @@ llvm = ['rustc_driver_impl/llvm']
 max_level_info = ['rustc_driver_impl/max_level_info']
 rustc_use_parallel_compiler = ['rustc_driver_impl/rustc_use_parallel_compiler']
 # tidy-alphabetical-end
+
+rustc_no_premopt = ["rustc_mir_transform/rustc_no_premopt"]
+rustc_no_fsa = ["rustc_mir_transform/rustc_no_fsa"]
+rustc_no_elision = ["rustc_middle/rustc_no_elision"]

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -43,3 +43,4 @@ tracing = "0.1"
 # tidy-alphabetical-start
 rustc_use_parallel_compiler = ["rustc-rayon", "rustc-rayon-core"]
 # tidy-alphabetical-end
+rustc_no_elision = []

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -27,3 +27,7 @@ rustc_trait_selection = { path = "../rustc_trait_selection" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end
+
+[features]
+rustc_no_premopt = []
+rustc_no_fsa = []

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -351,6 +351,7 @@ fn mir_promoted(
             &promote_pass,
             &simplify::SimplifyCfg::PromoteConsts,
             &coverage::InstrumentCoverage,
+            #[cfg(not(feature = "rustc_no_fsa"))]
             &check_finalizers::CheckFinalizers,
         ],
         Some(MirPhase::Analysis(AnalysisPhase::Initial)),
@@ -617,6 +618,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &deduplicate_blocks::DeduplicateBlocks,
             &large_enums::EnumSizeOpt { discrepancy: 128 },
             // Must come before CriticalCallEdges to prevent LLVM basic block ordering errors.
+            #[cfg(not(feature = "rustc_no_premopt"))]
             &remove_elidable_drops::RemoveElidableDrops,
             // Some cleanup necessary at least for LLVM and potentially other codegen backends.
             &add_call_guards::CriticalCallEdges,

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1517,17 +1517,6 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zunstable-options");
         }
 
-        // Alloy features
-        if stage != 0 && !self.config.finalizer_elision {
-            rustflags.arg("-Cno-finalizer-elision");
-        }
-        if stage != 0 && !self.config.finalizer_safety_analysis {
-            rustflags.arg("-Cno-finalizer-safety-analysis");
-        }
-        if stage != 0 && !self.config.premature_finalizer_prevention_optimize {
-            rustflags.arg("-Cno-premature-finalizer-prevention-opt");
-        }
-
         // Enable compile-time checking of `cfg` names, values and Cargo `features`.
         //
         // Note: `std`, `alloc` and `core` imports some dependencies by #[path] (like

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -773,6 +773,16 @@ impl Build {
             features.push("rustc_use_parallel_compiler");
         }
 
+        if !self.config.premature_finalizer_prevention_optimize {
+            features.push("rustc_no_premopt");
+        }
+        if !self.config.finalizer_safety_analysis {
+            features.push("rustc_no_fsa");
+        }
+        if !self.config.finalizer_elision {
+            features.push("rustc_no_elision");
+        }
+
         // If debug logging is on, then we want the default for tracing:
         // https://github.com/tokio-rs/tracing/blob/3dd5c03d907afdf2c39444a29931833335171554/tracing/src/level_filters.rs#L26
         // which is everything (including debug/trace/etc.)


### PR DESCRIPTION
Previously our setup passed a -C rustc option, but this didn't propagate to transitive dependencies so we had instances where programs would be compiled with a mix of different settings.