### PR TITLE
Switch to using bitflags for FSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
 name = "rustc_mir_transform"
 version = "0.0.0"
 dependencies = [
+ "bitflags 2.5.0",
  "either",
  "itertools 0.12.1",
  "rustc_arena",

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
+bitflags = "2.4.1"
 either = "1"
 itertools = "0.12"
 rustc_arena = { path = "../rustc_arena" }

--- a/tests/ui/runtime/gc/multithreaded.rs
+++ b/tests/ui/runtime/gc/multithreaded.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 #![feature(gc)]
 #![allow(dead_code)]
 

--- a/tests/ui/runtime/gc/thread_local.rs
+++ b/tests/ui/runtime/gc/thread_local.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 //@ no-prefer-dynamic
 // ignore-tidy-linelength
 #![feature(allocator_api)]

--- a/tests/ui/runtime/gc/zero_vecs.rs
+++ b/tests/ui/runtime/gc/zero_vecs.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 #![feature(gc)]
 #![feature(negative_impls)]
 #![feature(allocator_api)]

--- a/tests/ui/static/gc/fsa/stdlib_errors.rs
+++ b/tests/ui/static/gc/fsa/stdlib_errors.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 #![feature(gc)]
 #![feature(negative_impls)]
 


### PR DESCRIPTION
There are now various combinations of possible checks that FSA can perform which can change dynamically based on previously identified errors (e.g. the discovery of a thread-local means that we no longer check for other things). By passing this around as bit flags it becomes easier to write out the conditional logic.