### PR TITLE
Skip certain core library functions during FSA

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -938,6 +938,11 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes,
         "#[rustc_fsa_entry_point] is used to determine when types should be checked by finaliser safety analysis."
     ),
+    rustc_attr!(
+        rustc_fsa_safe_fn, Normal, template!(Word), ErrorFollowing,
+        EncodeCrossCrate::Yes,
+        "#[rustc_fsa_safe_fn] is used to declare that a function does not need to be checked by finaliser safety analysis."
+    ),
 
     // ==========================================================================
     // Internal attributes, Testing:

--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -527,6 +527,10 @@ impl<'ecx, 'tcx> DropCtxt<'ecx, 'tcx> {
                 // We've already checked this function. Ignore it!
                 continue;
             }
+            self.visited_fns.insert(instance);
+            if instance.def.get_attrs(self.ecx.tcx, sym::rustc_fsa_safe_fn).next().is_some() {
+                continue;
+            }
 
             self.visited_fns.insert(instance);
             let Some(mir) = self.ecx.prefer_instantiated_mir(instance) else {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1578,6 +1578,7 @@ symbols! {
         rustc_evaluate_where_clauses,
         rustc_expected_cgu_reuse,
         rustc_fsa_entry_point,
+        rustc_fsa_safe_fn,
         rustc_has_incoherent_inherent_impls,
         rustc_hidden_type_of_opaques,
         rustc_if_this_changed,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -51,15 +51,19 @@ extern "Rust" {
     // like `malloc`, `realloc`, and `free`, respectively.
     #[rustc_allocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
     #[rustc_deallocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
     #[rustc_reallocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn __rust_realloc(ptr: *mut u8, old_size: usize, align: usize, new_size: usize) -> *mut u8;
     #[rustc_allocator_zeroed]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8;
 
     static __rust_no_alloc_shim_is_unstable: u8;
@@ -115,6 +119,7 @@ pub use std::alloc::Global;
 /// }
 /// ```
 #[stable(feature = "global_alloc", since = "1.28.0")]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
@@ -158,6 +163,7 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
 ///
 /// See [`GlobalAlloc::realloc`].
 #[stable(feature = "global_alloc", since = "1.28.0")]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
 pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
@@ -192,6 +198,7 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 /// }
 /// ```
 #[stable(feature = "global_alloc", since = "1.28.0")]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
 pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
@@ -368,6 +375,7 @@ extern "Rust" {
     // This is the magic symbol to call the global alloc error handler. rustc generates
     // it to call `__rg_oom` if there is a `#[alloc_error_handler]`, or to call the
     // default implementations below (`__rdl_oom`) otherwise.
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn __rust_alloc_error_handler(size: usize, align: usize) -> !;
 }
 

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -213,6 +213,7 @@ impl<T> Box<T> {
     #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     #[rustc_diagnostic_item = "box_new"]
     pub fn new(x: T) -> Self {
         #[rustc_box]
@@ -1237,6 +1238,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Box<T, A> {
     #[inline]
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn drop(&mut self) {
         // the T in the Box is dropped by the compiler before the destructor is run
 

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -129,6 +129,7 @@ unsafe impl<T, A: Allocator> DropMethodFinalizerElidable for VecDeque<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for VecDeque<T, A> {
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn drop(&mut self) {
         /// Runs the destructor for all items in the slice when it gets dropped (normally or
         /// during unwinding).

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -579,6 +579,7 @@ where
 
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for RawVec<T, A> {
     /// Frees the memory owned by the `RawVec` *without* trying to drop its contents.
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn drop(&mut self) {
         if let Some((ptr, layout)) = self.current_memory() {
             unsafe { self.alloc.deallocate(ptr, layout) }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2440,6 +2440,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Arc<T, A> {
     /// drop(foo);    // Doesn't print anything
     /// drop(foo2);   // Prints "dropped!"
     /// ```
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     #[inline]
     fn drop(&mut self) {
         // Because `fetch_sub` is already atomic, we do not need to synchronize

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3281,6 +3281,7 @@ unsafe impl<T, A: Allocator> DropMethodFinalizerElidable for Vec<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {
+    #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
     fn drop(&mut self) {
         unsafe {
             // use drop for [T]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -987,6 +987,7 @@ pub const unsafe fn assume(b: bool) {
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 pub const fn likely(b: bool) -> bool {
     b
 }
@@ -1006,6 +1007,7 @@ pub const fn likely(b: bool) -> bool {
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 pub const fn unlikely(b: bool) -> bool {
     b
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -343,6 +343,7 @@ pub enum AssertKind {
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[track_caller]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[doc(hidden)]
 pub fn assert_failed<T, U>(
     kind: AssertKind,
@@ -361,6 +362,7 @@ where
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[track_caller]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[doc(hidden)]
 pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
     left: &T,
@@ -381,6 +383,7 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[track_caller]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 fn assert_failed_inner(
     kind: AssertKind,
     left: &dyn fmt::Debug,

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -60,6 +60,7 @@ macro_rules! assert_unsafe_precondition {
             #[rustc_no_mir_inline]
             #[inline]
             #[rustc_nounwind]
+            #[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
             #[rustc_const_unstable(feature = "const_ub_checks", issue = "none")]
             const fn precondition_check($($name:$ty),*) {
                 if !$e {

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1200,6 +1200,7 @@ pub fn _print(args: fmt::Arguments<'_>) {
     issue = "none"
 )]
 #[doc(hidden)]
+#[cfg_attr(not(bootstrap), rustc_fsa_safe_fn)]
 #[cfg(not(test))]
 pub fn _eprint(args: fmt::Arguments<'_>) {
     print_to(args, stderr, "stderr");


### PR DESCRIPTION
Some core library functions (e.g. compiler intrinsics, heap manipulation etc) either use lots of unsafety under the hood or simply do not expose any MIR that FSA can traverse. In this commit we introduce a rustc internal-only attribute (`rustc_fsa_safe_fn`) which allows us to skip over certain functions during FSA and not traverse them. This is never exposed to the user and lets us avoid rewriting Rust library functions with the `FinalizeUnchecked` wrapper.