### PR TITLE
Finalizer elision: special-case hashmaps and sets

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests;
 
+use core::gc::DropMethodFinalizerElidable;
+
 use hashbrown::hash_map as base;
 
 use self::Entry::*;
@@ -3346,3 +3348,6 @@ fn assert_covariance() {
         d
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<K, V, S> DropMethodFinalizerElidable for HashMap<K, V, S> {}

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests;
 
+use core::gc::DropMethodFinalizerElidable;
+
 use hashbrown::hash_set as base;
 
 use super::map::map_try_reserve_error;
@@ -2370,3 +2372,6 @@ fn assert_covariance() {
         d
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T, S> DropMethodFinalizerElidable for HashSet<T, S> {}

--- a/tests/ui/static/gc/elision/hashmap.rs
+++ b/tests/ui/static/gc/elision/hashmap.rs
@@ -1,0 +1,27 @@
+//@ run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+use std::mem::needs_finalizer;
+use std::collections::HashMap;
+use std::gc::Gc;
+
+static HM_TRIVIAL: bool = needs_finalizer::<HashMap<usize, usize>>();
+static HM_FIN_KEY: bool = needs_finalizer::<HashMap<HasDrop, HasDropNoFinalize>>();
+static HM_FIN_VAL: bool = needs_finalizer::<HashMap<HasDropNoFinalize, HasDrop>>();
+static HM_FIN_BOTH: bool = needs_finalizer::<HashMap<HasDrop, HasDrop>>();
+static HM_FIN_GC_KEY: bool = needs_finalizer::<HashMap<Gc<HasDropNoFinalize>, Gc<HasDrop>>>();
+static HM_FIN_GC_VAL: bool = needs_finalizer::<HashMap<Gc<HasDropNoFinalize>, Gc<HasDrop>>>();
+static HM_FIN_GC_BOTH: bool = needs_finalizer::<HashMap<Gc<HasDrop>, Gc<HasDrop>>>();
+
+fn main() {
+    assert!(!HM_TRIVIAL);
+    assert!(HM_FIN_KEY);
+    assert!(HM_FIN_VAL);
+    assert!(HM_FIN_BOTH);
+    assert!(!HM_FIN_GC_KEY);
+    assert!(!HM_FIN_GC_VAL);
+    assert!(!HM_FIN_GC_BOTH);
+}

--- a/tests/ui/static/gc/elision/hashset.rs
+++ b/tests/ui/static/gc/elision/hashset.rs
@@ -1,0 +1,41 @@
+//@ run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(dead_code)]
+include!{"./auxiliary/types.rs"}
+
+use std::mem::needs_finalizer;
+use std::collections::HashSet;
+use std::gc::Gc;
+
+static HS_TRIVIAL: bool = needs_finalizer::<HashSet<usize>>();
+static HS_FINALIZABLE: bool = needs_finalizer::<HashSet<HasDrop>>();
+static HS_UNFINALIZABLE: bool = needs_finalizer::<HashSet<HasDropNoFinalize>>();
+static HS_TUPLE_UNFINALIZABLE: bool = needs_finalizer::<HashSet<(HasDropNoFinalize, usize)>>();
+static HS_TUPLE_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, HasDrop)>>();
+static HS_TUPLE_CONTAINS_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, usize)>>();
+static HS_HS_FINALIZABLE: bool = needs_finalizer::<HashSet<HashSet<HasDrop>>>();
+static HS_HS_UNFINALIZABLE: bool = needs_finalizer::<HashSet<HashSet<HasDropNoFinalize>>>();
+static HS_STRING: bool = needs_finalizer::<HashSet<String>>();
+static HS_BOX_FINALIZABLE: bool = needs_finalizer::<HashSet<Box<HasDrop>>>();
+static HS_BOX_UNFINALIZABLE: bool = needs_finalizer::<HashSet<Box<HasDropNoFinalize>>>();
+static HS_TUPLE_GC_UNFINALIZABLE: bool = needs_finalizer::<HashSet<(HasDropNoFinalize, Gc<HasDrop>)>>();
+static HS_TUPLE_GC_FINALIZABLE: bool = needs_finalizer::<HashSet<(HasDrop, Gc<HasDrop>)>>();
+static HS_COLLECTABLE_NO_DROP_ELEMENT: bool = needs_finalizer::<HashSet<NonAnnotated>>();
+
+fn main() {
+    assert!(!HS_TRIVIAL);
+    assert!(HS_FINALIZABLE);
+    assert!(!HS_UNFINALIZABLE);
+    assert!(!HS_TUPLE_UNFINALIZABLE);
+    assert!(HS_TUPLE_FINALIZABLE);
+    assert!(HS_TUPLE_CONTAINS_FINALIZABLE);
+    assert!(HS_HS_FINALIZABLE);
+    assert!(!HS_HS_UNFINALIZABLE);
+    assert!(!HS_STRING);
+    assert!(HS_BOX_FINALIZABLE);
+    assert!(!HS_BOX_UNFINALIZABLE);
+    assert!(!HS_TUPLE_GC_UNFINALIZABLE);
+    assert!(HS_TUPLE_GC_FINALIZABLE);
+    assert!(!HS_COLLECTABLE_NO_DROP_ELEMENT);
+}


### PR DESCRIPTION
In an ideal world, we would be able to impl `DropMethodFinalizeElidable` on `HashMap` and `HashSet` and get the expected behaviour as we do with `Vec` etc.

However, the backing store for HashMaps and HashSets (hashbrown) is not part of the standard library, and is imported as a separate crate. Rather than maintaining our own fork and trying to keep this in-sync each time we update rustc, it's easier to special case these two types here inside the compiler as they're the only types which need it.