### PR TITLE
Use inline barriers for premature finalizer prevention

### DIFF
--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -301,7 +301,11 @@ impl<T: ?Sized> Drop for Gc<T> {
     fn drop(&mut self) {
         #[cfg(feature = "log-stats")]
         GC_COUNTERS.barriers_visited.fetch_add(1, atomic::Ordering::Relaxed);
-        keep_alive(self);
+        unsafe {
+            // asm macros clobber by default, so this is enough to introduce a
+            // barrier.
+            core::arch::asm!("/* {0} */", in(reg) self);
+        }
     }
 }
 


### PR DESCRIPTION
This replaces the call to `GC_keep_alive` inside BDWGC, which uses the same barrier. By inlining, we remove the additional call overhead and isolate the performance implications of premature finalizer prevention to just the barrier. This was noticed when looking at the generated LLVM IR (and ASM): the call to `GC_keep_alive` never appeared to inline across the BDWGC boundary. Of course, this is expected where libgc is a shared object, but it even happens when it's statically linked.

For our premopt experiment, this removes some of the strange results we were seeing where some benchmarks (e.g. SOM quicksort and fibonacci) were ~20% slower on optimized barriers than naive barriers.
