### PR TITLE
Log compile-time stats about Alloy programs

### DIFF
--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -37,5 +37,6 @@ rustc_randomized_layouts = ['rustc_driver_impl/rustc_randomized_layouts']
 # tidy-alphabetical-end
 
 rustc_no_premopt = ["rustc_mir_transform/rustc_no_premopt"]
+rustc_log_gc_stats = ["rustc_mir_transform/rustc_log_gc_stats"]
 rustc_no_fsa = ["rustc_mir_transform/rustc_no_fsa"]
 rustc_no_elision = ["rustc_middle/rustc_no_elision"]

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -35,3 +35,4 @@ tracing = "0.1"
 [features]
 rustc_no_premopt = []
 rustc_no_fsa = []
+rustc_log_gc_stats = []

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -156,6 +156,7 @@ declare_passes! {
     mod large_enums : EnumSizeOpt;
     mod lower_intrinsics : LowerIntrinsics;
     mod lower_slice_len : LowerSliceLenCalls;
+    mod log_gc_stats : LogGcStats;
     mod match_branches : MatchBranchSimplification;
     mod mentioned_items : MentionedItems;
     mod multiple_return_terminators : MultipleReturnTerminators;
@@ -736,6 +737,8 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             // Cleanup for human readability, off by default.
             &prettify::ReorderBasicBlocks,
             &prettify::ReorderLocals,
+            #[cfg(feature = "rustc_log_gc_stats")]
+            &log_gc_stats::LogGcStats,
             // Dump the end result for testing and debugging purposes.
             &dump_mir::Marker("PreCodegen"),
         ],

--- a/compiler/rustc_mir_transform/src/log_gc_stats.rs
+++ b/compiler/rustc_mir_transform/src/log_gc_stats.rs
@@ -1,0 +1,90 @@
+#![cfg_attr(not(feature = "rustc_log_gc_stats"), allow(dead_code))]
+use std::io::Write;
+use std::{env, fs};
+
+use rustc_hir::def_id::DefId;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::sym;
+use tracing::trace;
+
+use crate::MirPass;
+
+#[derive(Default)]
+struct GcStats {
+    num_gcs: u64,
+    num_rcs: u64,
+    num_weaks: u64,
+    num_arcs: u64,
+    num_arcweaks: u64,
+}
+
+pub(super) struct LogGcStats;
+
+impl<'tcx> MirPass<'tcx> for LogGcStats {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if env::var("ALLOY_RUSTC_LOG").is_err() {
+            return;
+        }
+        trace!("Calculating GcStats on {:?}", body.source);
+
+        if in_std_lib(tcx, body.source.def_id()) {
+            // A hacky way of checking if we're in the standard library.
+            // If we are, we don't want to record GC statistics.
+            return;
+        }
+
+        let gc = tcx.get_diagnostic_item(sym::gc).unwrap();
+        let rc = tcx.get_diagnostic_item(sym::Rc).unwrap();
+        let arc = tcx.get_diagnostic_item(sym::Arc).unwrap();
+        let weak = tcx.get_diagnostic_item(sym::RcWeak).unwrap();
+        let arcweak = tcx.get_diagnostic_item(sym::ArcWeak).unwrap();
+
+        let mut stats = GcStats::default();
+
+        for decl in body.local_decls().iter().skip(1) {
+            if decl.ty.ty_adt_def().is_none() {
+                continue;
+            }
+
+            let did = decl.ty.ty_adt_def().unwrap().did();
+            match did {
+                _ if did == gc => stats.num_gcs += 1,
+                _ if did == rc => stats.num_rcs += 1,
+                _ if did == arc => stats.num_arcs += 1,
+                _ if did == weak => stats.num_weaks += 1,
+                _ if did == arcweak => stats.num_arcweaks += 1,
+                _ => (),
+            }
+        }
+
+        let mut filename = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(env::var("ALLOY_RUSTC_LOG").unwrap())
+            .unwrap();
+
+        let headers = "fn,num_gcs,num_rcs,num_arcs,num_weaks,num_arcweaks";
+        let out = format!(
+            "{},{},{},{},{},{}\n",
+            tcx.def_path_str(body.source.def_id()),
+            stats.num_gcs,
+            stats.num_rcs,
+            stats.num_arcs,
+            stats.num_weaks,
+            stats.num_arcweaks,
+        );
+        write!(filename, "{}", format!("{headers}\n{out}")).unwrap();
+    }
+    fn is_required(&self) -> bool {
+        true
+    }
+}
+
+fn in_std_lib<'tcx>(tcx: TyCtxt<'tcx>, did: DefId) -> bool {
+    let alloc_crate = tcx.get_diagnostic_item(sym::Rc).map_or(false, |x| did.krate == x.krate);
+    let core_crate = tcx.get_diagnostic_item(sym::RefCell).map_or(false, |x| did.krate == x.krate);
+    let std_crate = tcx.get_diagnostic_item(sym::Mutex).map_or(false, |x| did.krate == x.krate);
+    alloc_crate || std_crate || core_crate
+}

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -726,6 +726,9 @@ impl Build {
         if !self.config.finalizer_elision {
             features.push("rustc_no_elision");
         }
+        if !self.config.log_stats {
+            features.push("rustc_log_gc_stats");
+        }
 
         // If debug logging is on, then we want the default for tracing:
         // https://github.com/tokio-rs/tracing/blob/3dd5c03d907afdf2c39444a29931833335171554/tracing/src/level_filters.rs#L26


### PR DESCRIPTION
This allows us to get useful information during benchmarking, such as the number of `Gc<T>` pointers in source in the program.

We exclude the standard library from our statistics generation.