### PR TITLE
Fix GC metric collection

### DIFF
--- a/library/std/src/gc.rs
+++ b/library/std/src/gc.rs
@@ -49,23 +49,13 @@ use core::ptr::{self, NonNull, drop_in_place};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 #[cfg(feature = "log-stats")]
-use core::sync::atomic::{self, AtomicU64};
+use core::sync::atomic;
 use core::{fmt, iter};
 
+#[cfg(feature = "log-stats")]
+use crate::alloc::GC_COUNTERS;
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::{Global, handle_alloc_error};
-
-#[cfg(feature = "log-stats")]
-#[derive(Default)]
-struct GcCounters {
-    finalizers_registered: AtomicU64,
-    finalizers_elidable: AtomicU64,
-    allocated_gc: AtomicU64,
-    allocated_boxed: AtomicU64,
-    allocated_rc: AtomicU64,
-    allocated_arc: AtomicU64,
-    barriers_visited: AtomicU64,
-}
 
 #[cfg(feature = "log-stats")]
 #[derive(Debug, Copy, Clone)]
@@ -83,17 +73,6 @@ pub struct GcStats {
     pub allocated_arc: u64,
     pub num_gcs: u64,
 }
-
-#[cfg(feature = "log-stats")]
-static GC_COUNTERS: GcCounters = GcCounters {
-    finalizers_registered: AtomicU64::new(0),
-    finalizers_elidable: AtomicU64::new(0),
-    allocated_gc: AtomicU64::new(0),
-    allocated_boxed: AtomicU64::new(0),
-    allocated_rc: AtomicU64::new(0),
-    allocated_arc: AtomicU64::new(0),
-    barriers_visited: AtomicU64::new(0),
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 // BDWGC Allocator

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -686,8 +686,8 @@ impl Build {
         if self.config.premature_finalizer_prevention {
             features.insert("premature-finalizer-prevention");
         }
-        if self.config.finalizer_elision {
-            features.insert("finalizer-elision");
+        if self.config.premature_finalizer_prevention_optimize {
+            features.insert("premature-finalizer-prevention-optimize");
         }
         if self.config.bdwgc_link_shared {
             features.insert("bdwgc-link-shared");


### PR DESCRIPTION
Previously the stat counts for the alloc crate were recorded incorrectly because as any heap allocation recorded before the first `GC:new` was being overwritten. This resulted in us incorrectly recording the ratio of GC to non-GC heap objects and over-representing how many objects were under control of GC.