### PR TITLE
Check for misaligned pointers in packed structs

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -504,6 +504,9 @@ lint_metavariable_still_repeating = variable `{$name}` is still repeating at thi
 
 lint_metavariable_wrong_operator = meta-variable repeats with different Kleene operator
 
+lint_misaligned_gc_pointers = contains a non-word aligned field `{$ty}`
+    .note = Alloy uses conservative GC and traces for pointers word-by-word, so this field could inadvertantly hide a pointer
+
 lint_missing_fragment_specifier = missing fragment specifier
 
 lint_missing_unsafe_on_extern = extern blocks should be unsafe

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -60,6 +60,7 @@ mod levels;
 mod lints;
 mod macro_expr_fragment_specifier_2024_migration;
 mod map_unit_fn;
+mod misaligned_gc_pointers;
 mod multiple_supertrait_upcastable;
 mod non_ascii_idents;
 mod non_fmt_panic;
@@ -98,6 +99,7 @@ use invalid_from_utf8::*;
 use let_underscore::*;
 use macro_expr_fragment_specifier_2024_migration::*;
 use map_unit_fn::*;
+use misaligned_gc_pointers::*;
 use multiple_supertrait_upcastable::*;
 use non_ascii_idents::*;
 use non_fmt_panic::NonPanicFmt;
@@ -244,6 +246,7 @@ late_lint_methods!(
             IfLetRescope: IfLetRescope::default(),
             StaticMutRefs: StaticMutRefs,
             UnqualifiedLocalImports: UnqualifiedLocalImports,
+            MisalignedGcPointers: MisalignedGcPointers,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1900,6 +1900,17 @@ impl<'a> LintDiagnostic<'a, ()> for ImproperCTypes<'_> {
     }
 }
 
+pub(crate) struct MisalignedGcPointers<'a> {
+    pub ty: Ty<'a>,
+}
+
+impl<'a> LintDiagnostic<'a, ()> for MisalignedGcPointers<'_> {
+    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
+        diag.primary_message(fluent::lint_misaligned_gc_pointers);
+        diag.arg("ty", self.ty);
+    }
+}
+
 #[derive(LintDiagnostic)]
 #[diag(lint_variant_size_differences)]
 pub(crate) struct VariantSizeDifferencesDiag {

--- a/compiler/rustc_lint/src/misaligned_gc_pointers.rs
+++ b/compiler/rustc_lint/src/misaligned_gc_pointers.rs
@@ -1,0 +1,131 @@
+#![allow(dead_code)]
+#![allow(unused_must_use)]
+use rustc_hir as hir;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_session::{declare_lint, declare_lint_pass};
+
+use crate::lints::MisalignedGcPointers as MisalignedLint;
+use crate::{LateContext, LateLintPass, LintContext};
+
+declare_lint! {
+    /// The `misaligned_gc_pointers` lint checks that packed structs have no
+    /// traceable fields.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #[repr(packed)]
+    /// struct S(u8, *mut u8);
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Packed structs have a min alignment of 1 byte, so fields which need to
+    /// be traced by the GC --  such as `*mut u8` -- are not guaranteed to be
+    /// word-aligned. This can cause fields to be missed by the collector and is
+    /// undefined behaviour.
+    pub MISALIGNED_GC_POINTERS,
+    Deny,
+    "Packed structs should not contain traceable values",
+}
+
+declare_lint_pass!(MisalignedGcPointers => [MISALIGNED_GC_POINTERS]);
+
+const MIN_ALIGN: usize = std::mem::align_of::<usize>();
+
+impl<'tcx> LateLintPass<'tcx> for MisalignedGcPointers {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
+        match item.kind {
+            hir::ItemKind::Struct(..) => {
+                let mut offset = 0;
+                let adt_def = cx.tcx.adt_def(item.owner_id.to_def_id());
+                if !adt_def.repr().packed() {
+                    return;
+                }
+
+                let ty = cx.tcx.type_of(adt_def.did()).skip_binder();
+                match has_correct_alignment(&mut offset, cx.tcx, ty) {
+                    Ok(()) => (),
+                    Err(err) => {
+                        cx.emit_span_lint(
+                            MISALIGNED_GC_POINTERS,
+                            item.span,
+                            MisalignedLint { ty: err.ty() },
+                        );
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AlignError<'tcx> {
+    MisalignedPointer(Ty<'tcx>),
+    MisalignedUInt(Ty<'tcx>),
+    MisalignedInt(Ty<'tcx>),
+    TySizeUnavailable(Ty<'tcx>),
+}
+
+impl<'tcx> AlignError<'tcx> {
+    fn ty(&self) -> Ty<'tcx> {
+        match self {
+            AlignError::MisalignedPointer(ty)
+            | AlignError::MisalignedUInt(ty)
+            | AlignError::MisalignedInt(ty)
+            | AlignError::TySizeUnavailable(ty) => *ty,
+        }
+    }
+}
+
+fn has_correct_alignment<'tcx>(
+    offset: &mut usize,
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+) -> Result<(), AlignError<'tcx>> {
+    match ty.kind() {
+        ty::Ref(..) | ty::RawPtr(..) if *offset % MIN_ALIGN != 0 => {
+            return Err(AlignError::MisalignedPointer(ty));
+        }
+        ty::Uint(i)
+            if ((i.bit_width().is_none()
+                || i.bit_width().unwrap() == u64::try_from(size_of::<usize>()).unwrap() * 8)
+                && *offset % MIN_ALIGN != 0) =>
+        {
+            return Err(AlignError::MisalignedUInt(ty));
+        }
+        ty::Int(i)
+            if ((i.bit_width().is_none()
+                || i.bit_width().unwrap() == u64::try_from(size_of::<usize>()).unwrap() * 8)
+                && *offset % MIN_ALIGN != 0) =>
+        {
+            return Err(AlignError::MisalignedInt(ty));
+        }
+        ty::Tuple(tys) => tys.iter().try_for_each(|t| has_correct_alignment(offset, tcx, t))?,
+        ty::Array(t, length) => {
+            has_correct_alignment(offset, tcx, *t)?;
+            *offset = type_size(tcx, *t)? * (length.try_to_target_usize(tcx).unwrap() as usize - 1);
+        }
+        ty::Adt(adt_def, _) => {
+            for field_def in adt_def.all_fields() {
+                let field_ty = tcx.type_of(field_def.did).skip_binder();
+                has_correct_alignment(offset, tcx, field_ty)?;
+            }
+        }
+        _ => *offset += type_size(tcx, ty)?,
+    }
+    return Ok(());
+}
+
+fn type_size<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Result<usize, AlignError<'tcx>> {
+    match tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty)) {
+        Ok(layout) => {
+            let size = layout.size;
+            Ok(size.bytes_usize())
+        }
+        Err(_) => Err(AlignError::TySizeUnavailable(ty)),
+    }
+}

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(bootstrap), allow(misaligned_gc_pointers))]
 use std::fmt;
 use std::num::NonZero;
 

--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "rustc_no_fsa", allow(dead_code))]
 #![allow(rustc::untranslatable_diagnostic)]
 #![allow(rustc::diagnostic_outside_of_impl)]
+#![allow(rustdoc::broken_intra_doc_links)]
 use std::collections::VecDeque;
 
 use bitflags::bitflags;

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -1,3 +1,4 @@
+#![allow(misaligned_gc_pointers)]
 use core::cell::RefCell;
 use core::marker::Freeze;
 use core::mem::{self, MaybeUninit};

--- a/tests/codegen/const-vector.rs
+++ b/tests/codegen/const-vector.rs
@@ -9,6 +9,7 @@
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]
 #![allow(non_camel_case_types)]
+#![allow(misaligned_gc_pointers)]
 
 // Setting up structs that can be used as const vectors
 #[repr(simd)]

--- a/tests/codegen/simd/packed-simd.rs
+++ b/tests/codegen/simd/packed-simd.rs
@@ -6,6 +6,7 @@
 #![crate_type = "lib"]
 #![no_std]
 #![feature(repr_simd, core_intrinsics)]
+#![allow(misaligned_gc_pointers)]
 use core::intrinsics::simd as intrinsics;
 use core::{mem, ptr};
 

--- a/tests/codegen/swap-small-types.rs
+++ b/tests/codegen/swap-small-types.rs
@@ -2,6 +2,7 @@
 //@ only-x86_64
 
 #![crate_type = "lib"]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem::swap;
 

--- a/tests/mir-opt/const_allocation3.rs
+++ b/tests/mir-opt/const_allocation3.rs
@@ -3,6 +3,7 @@
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR const_allocation3.main.GVN.after.mir
+#![allow(misaligned_gc_pointers)]
 fn main() {
     FOO;
 }

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
@@ -2,6 +2,7 @@
 //@ [no_flag] check-pass
 //@ [with_flag] compile-flags: -Zextra-const-ub-checks
 #![feature(never_type)]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem::transmute;
 use std::ptr::addr_of;

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:29:20
+  --> $DIR/detect-extra-ub.rs:30:20
    |
 LL |     let _x: bool = transmute(3u8);
    |                    ^^^^^^^^^^^^^^ constructing invalid value: encountered 0x03, but expected a boolean
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:35:21
+  --> $DIR/detect-extra-ub.rs:36:21
    |
 LL |     let _x: usize = transmute(&3u8);
    |                     ^^^^^^^^^^^^^^^ constructing invalid value: encountered a pointer, but expected an integer
@@ -14,7 +14,7 @@ LL |     let _x: usize = transmute(&3u8);
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:41:28
+  --> $DIR/detect-extra-ub.rs:42:28
    |
 LL |     let _x: PtrSizedEnum = transmute(&3u8);
    |                            ^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered a pointer, but expected an integer
@@ -23,7 +23,7 @@ LL |     let _x: PtrSizedEnum = transmute(&3u8);
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:48:30
+  --> $DIR/detect-extra-ub.rs:49:30
    |
 LL |     let _x: (usize, usize) = transmute(x);
    |                              ^^^^^^^^^^^^ constructing invalid value at .0: encountered a pointer, but expected an integer
@@ -32,19 +32,19 @@ LL |     let _x: (usize, usize) = transmute(x);
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:54:20
+  --> $DIR/detect-extra-ub.rs:55:20
    |
 LL |     let _x: &u32 = transmute(&[0u8; 4]);
    |                    ^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 4 byte alignment but found 1)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:62:13
+  --> $DIR/detect-extra-ub.rs:63:13
    |
 LL |     let v = *addr_of!(data).cast::<UninhDiscriminant>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:82:16
+  --> $DIR/detect-extra-ub.rs:83:16
    |
 LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [0]: encountered a partial pointer or a mix of pointers
@@ -53,7 +53,7 @@ LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/detect-extra-ub.rs:97:16
+  --> $DIR/detect-extra-ub.rs:98:16
    |
 LL |     let _val = &*slice;
    |                ^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object

--- a/tests/ui/mir/alignment/packed.rs
+++ b/tests/ui/mir/alignment/packed.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ compile-flags: -C debug-assertions
+#![allow(misaligned_gc_pointers)]
 
 #[repr(packed)]
 struct Misaligner {

--- a/tests/ui/packed/dyn-trait.rs
+++ b/tests/ui/packed/dyn-trait.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(misaligned_gc_pointers)]
 use std::ptr::addr_of;
 
 // When the unsized tail is a `dyn Trait`, its alignments is only dynamically known. This means the

--- a/tests/ui/packed/issue-46152.rs
+++ b/tests/ui/packed/issue-46152.rs
@@ -3,6 +3,7 @@
 #![allow(unused_variables)]
 #![allow(non_local_definitions)]
 #![feature(unsize, coerce_unsized)]
+#![allow(misaligned_gc_pointers)]
 
 #[repr(packed)]
 struct UnalignedPtr<'a, T: ?Sized>

--- a/tests/ui/packed/packed-struct-address-of-element.rs
+++ b/tests/ui/packed/packed-struct-address-of-element.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
+#![allow(misaligned_gc_pointers)]
 //@ ignore-emscripten weird assertion?
 
 #[repr(packed)]

--- a/tests/ui/packed/packed-struct-drop-aligned.rs
+++ b/tests/ui/packed/packed-struct-drop-aligned.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![feature(coroutines, stmt_expr_attributes)]
 #![feature(coroutine_trait)]
+#![allow(misaligned_gc_pointers)]
 use std::cell::Cell;
 use std::mem;
 use std::ops::Coroutine;

--- a/tests/ui/packed/packed-struct-generic-layout.rs
+++ b/tests/ui/packed/packed-struct-generic-layout.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(overflowing_literals)]
+#![allow(misaligned_gc_pointers)]
 
 
 use std::mem;

--- a/tests/ui/packed/packed-struct-generic-size.rs
+++ b/tests/ui/packed/packed-struct-generic-size.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_comparisons)]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem;
 

--- a/tests/ui/packed/packed-struct-match.rs
+++ b/tests/ui/packed/packed-struct-match.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(misaligned_gc_pointers)]
 
 #[repr(packed)]
 struct Foo1 {

--- a/tests/ui/packed/packed-struct-optimized-enum.rs
+++ b/tests/ui/packed/packed-struct-optimized-enum.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(misaligned_gc_pointers)]
 #[repr(packed)]
 struct Packed<T: Copy>(#[allow(dead_code)] T);
 

--- a/tests/ui/packed/packed-struct-size.rs
+++ b/tests/ui/packed/packed-struct-size.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem;
 

--- a/tests/ui/packed/packed-struct-vec.rs
+++ b/tests/ui/packed/packed-struct-vec.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(misaligned_gc_pointers)]
 
 use std::fmt;
 use std::mem;

--- a/tests/ui/packed/packed-tuple-struct-size.rs
+++ b/tests/ui/packed/packed-tuple-struct-size.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem;
 

--- a/tests/ui/packed/packed-with-inference-vars-issue-61402.rs
+++ b/tests/ui/packed/packed-with-inference-vars-issue-61402.rs
@@ -7,6 +7,7 @@
 // that this doesn't ICE.
 
 #![allow(unused_imports, dead_code)]
+#![allow(misaligned_gc_pointers)]
 
 pub struct S;
 

--- a/tests/ui/rfcs/rfc-2151-raw-identifiers/attr.rs
+++ b/tests/ui/rfcs/rfc-2151-raw-identifiers/attr.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(misaligned_gc_pointers)]
 use std::mem;
 
 #[r#repr(r#C, r#packed)]

--- a/tests/ui/simd/repr_packed.rs
+++ b/tests/ui/simd/repr_packed.rs
@@ -2,6 +2,7 @@
 
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+#![allow(misaligned_gc_pointers)]
 
 use std::intrinsics::simd::simd_add;
 

--- a/tests/ui/static/gc/tracing/packed-structs.rs
+++ b/tests/ui/static/gc/tracing/packed-structs.rs
@@ -1,0 +1,85 @@
+#![deny(misaligned_gc_pointers)]
+#![feature(gc)]
+
+struct RawPtr(*mut u8);
+
+#[repr(packed)]
+struct PackedUsize { //~ ERROR: contains a non-word aligned field `usize`
+    x: u16,
+    y: usize,
+}
+
+#[repr(packed)]
+struct PackedUsizeAligned {
+    x: u16,
+    y: u16,
+    z: u32,
+    a: usize,
+}
+
+#[repr(packed)]
+struct PackedI64 { //~ ERROR: contains a non-word aligned field `i64`
+    x: u16,
+    y: i64,
+}
+
+#[repr(packed)]
+struct PackedU64 { //~ ERROR: contains a non-word aligned field `u64`
+    x: u16,
+    y: u64,
+}
+
+#[repr(packed)]
+struct PackedRef<'a> { //~ ERROR: contains a non-word aligned field `&'a usize`
+    x: u16,
+    y: &'a usize,
+}
+
+#[repr(packed)]
+struct PackedRefAligned<'a> {
+    x: u16,
+    y: u16,
+    z: u32,
+    a: &'a usize,
+}
+
+#[repr(packed)]
+struct PackedRaw { //~ ERROR: contains a non-word aligned field `*mut usize`
+    x: u16,
+    y: *mut usize,
+}
+
+#[repr(packed)]
+struct PackedRawAligned {
+    x: u16,
+    y: u16,
+    z: u32,
+    a: *mut usize,
+}
+
+#[repr(packed)]
+struct PackedTuple { //~ ERROR: contains a non-word aligned field `usize`
+    x: u16,
+    y: (usize, u8),
+}
+
+#[repr(packed)]
+struct PackedArray { //~ ERROR: contains a non-word aligned field `usize`
+    x: u16,
+    y: [usize; 3],
+}
+
+#[repr(packed)]
+struct PackedArrayOffset { //~ ERROR: contains a non-word aligned field `u64`
+    x: usize,
+    y: [u16; 3],
+    z: u64
+}
+
+#[repr(packed)]
+struct PackedAdt { //~ ERROR: contains a non-word aligned field `*mut u8`
+    x: u16,
+    y: RawPtr,
+}
+
+fn main() {}

--- a/tests/ui/static/gc/tracing/packed-structs.stderr
+++ b/tests/ui/static/gc/tracing/packed-structs.stderr
@@ -1,0 +1,90 @@
+error: contains a non-word aligned field `usize`
+  --> $DIR/packed-structs.rs:7:1
+   |
+LL | / struct PackedUsize {
+LL | |     x: u16,
+LL | |     y: usize,
+LL | | }
+   | |_^
+   |
+note: the lint level is defined here
+  --> $DIR/packed-structs.rs:1:9
+   |
+LL | #![deny(misaligned_gc_pointers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: contains a non-word aligned field `i64`
+  --> $DIR/packed-structs.rs:21:1
+   |
+LL | / struct PackedI64 {
+LL | |     x: u16,
+LL | |     y: i64,
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `u64`
+  --> $DIR/packed-structs.rs:27:1
+   |
+LL | / struct PackedU64 {
+LL | |     x: u16,
+LL | |     y: u64,
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `&'a usize`
+  --> $DIR/packed-structs.rs:33:1
+   |
+LL | / struct PackedRef<'a> {
+LL | |     x: u16,
+LL | |     y: &'a usize,
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `*mut usize`
+  --> $DIR/packed-structs.rs:47:1
+   |
+LL | / struct PackedRaw {
+LL | |     x: u16,
+LL | |     y: *mut usize,
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `usize`
+  --> $DIR/packed-structs.rs:61:1
+   |
+LL | / struct PackedTuple {
+LL | |     x: u16,
+LL | |     y: (usize, u8),
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `usize`
+  --> $DIR/packed-structs.rs:67:1
+   |
+LL | / struct PackedArray {
+LL | |     x: u16,
+LL | |     y: [usize; 3],
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `u64`
+  --> $DIR/packed-structs.rs:73:1
+   |
+LL | / struct PackedArrayOffset {
+LL | |     x: usize,
+LL | |     y: [u16; 3],
+LL | |     z: u64
+LL | | }
+   | |_^
+
+error: contains a non-word aligned field `*mut u8`
+  --> $DIR/packed-structs.rs:80:1
+   |
+LL | / struct PackedAdt {
+LL | |     x: u16,
+LL | |     y: RawPtr,
+LL | | }
+   | |_^
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/structs-enums/align-struct.rs
+++ b/tests/ui/structs-enums/align-struct.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code, unused_allocation)]
+#![allow(misaligned_gc_pointers)]
 
 use std::mem;
 


### PR DESCRIPTION
This adds a compulsary lint pass which checks that packed structs containing word-sized types commonly used to hold pointers are aligned to a word boundary.

We did this before [1], but for some reason I dropped the commit when we sync'd with upstream. I've updated this to now work with the recent HIR changes in rustc.

[1]: https://github.com/softdevteam/alloy/pull/24