### PR TITLE
Use BDWGC finalization callback API

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -18,6 +18,7 @@ use core::sync::atomic::AtomicU64;
 pub static GC_COUNTERS: GcCounters = GcCounters {
     finalizers_registered: AtomicU64::new(0),
     finalizers_elidable: AtomicU64::new(0),
+    finalizers_completed: AtomicU64::new(0),
     barriers_visited: AtomicU64::new(0),
     allocated_gc: AtomicU64::new(0),
     allocated_boxed: AtomicU64::new(0),
@@ -32,6 +33,7 @@ pub static GC_COUNTERS: GcCounters = GcCounters {
 pub struct GcCounters {
     pub finalizers_registered: AtomicU64,
     pub finalizers_elidable: AtomicU64,
+    pub finalizers_completed: AtomicU64,
     pub barriers_visited: AtomicU64,
     pub allocated_gc: AtomicU64,
     pub allocated_boxed: AtomicU64,

--- a/library/bdwgc/src/lib.rs
+++ b/library/bdwgc/src/lib.rs
@@ -79,7 +79,13 @@ extern "C" {
 
     pub fn GC_keep_alive(ptr: *mut u8);
 
-    pub fn GC_finalized_total() -> u64;
+    pub fn GC_set_finalize_on_demand(state: i32);
+
+    pub fn GC_set_finalizer_notifier(f: extern "C" fn());
+
+    pub fn GC_should_invoke_finalizers() -> u32;
+
+    pub fn GC_invoke_finalizers() -> u64;
 
     pub fn GC_get_gc_no() -> u64;
 }


### PR DESCRIPTION
With this API, Boehm automatically invokes our finalization-thread code when there is finalization work to do (using GC_set_finalizer_notifier) and handles synchronization internally.