### PR TITLE
Add API for enabling/disabling collector

### DIFF
--- a/library/bdwgc/src/lib.rs
+++ b/library/bdwgc/src/lib.rs
@@ -88,4 +88,10 @@ extern "C" {
     pub fn GC_invoke_finalizers() -> u64;
 
     pub fn GC_get_gc_no() -> u64;
+
+    pub fn GC_enable();
+
+    pub fn GC_is_disabled() -> i32;
+
+    pub fn GC_disable();
 }

--- a/tests/ui/runtime/gc/disable.rs
+++ b/tests/ui/runtime/gc/disable.rs
@@ -1,0 +1,25 @@
+//@ run-pass
+// ignore-tidy-linelength
+#![feature(gc)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+
+use std::gc::{disable, enable, is_enabled, try_enable};
+
+fn main() {
+    assert!(is_enabled());
+    disable();
+    disable();
+
+    assert!(!is_enabled());
+
+    assert!(!try_enable());
+    assert!(try_enable());
+
+    disable();
+    disable();
+    disable();
+
+    enable();
+    assert!(is_enabled());
+}


### PR DESCRIPTION
This is useful for debugging and, for us in particular, benchmarking. Before this, we had to make sure that we passed GC_DONT_GC=true|false to the correct benchmark configuration which was hacky and errorprone. Now we can ensure that GC is enabled or disabled as part of the benchmark patch file.