### PR TITLE
 Automatically generate BDWGC bindings 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,6 @@
 [submodule "src/bdwgc"]
 	path = src/bdwgc
 	url = https://github.com/softdevteam/bdwgc
+[submodule "src/tools/bindgen"]
+	path = src/tools/bindgen
+	url = https://github.com/rust-lang/rust-bindgen.git

--- a/library/bdwgc/src/lib.rs
+++ b/library/bdwgc/src/lib.rs
@@ -1,4 +1,8 @@
 #![no_std]
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[repr(C)]
 #[derive(Default)]
@@ -28,70 +32,4 @@ pub struct ProfileStats {
     pub reclaimed_bytes_before_gc: usize,
     /// Number of bytes freed explicitly since the recent GC.
     pub expl_freed_bytes_since_gc: usize,
-}
-
-#[link(name = "gc")]
-extern "C" {
-    pub fn GC_malloc(nbytes: usize) -> *mut u8;
-
-    pub fn GC_posix_memalign(mem_ptr: *mut *mut u8, align: usize, nbytes: usize) -> i32;
-
-    pub fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
-
-    pub fn GC_free(dead: *mut u8);
-
-    pub fn GC_base(mem_ptr: *mut u8) -> *mut u8;
-
-    pub fn GC_register_finalizer(
-        ptr: *mut u8,
-        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-        client_data: *mut u8,
-        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-        old_client_data: *mut *mut u8,
-    );
-
-    pub fn GC_register_finalizer_no_order(
-        ptr: *mut u8,
-        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-        client_data: *mut u8,
-        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-        old_client_data: *mut *mut u8,
-    );
-
-    pub fn GC_gcollect();
-
-    pub fn GC_thread_is_registered() -> u32;
-
-    pub fn GC_pthread_create(
-        native: *mut libc::pthread_t,
-        attr: *const libc::pthread_attr_t,
-        f: extern "C" fn(_: *mut libc::c_void) -> *mut libc::c_void,
-        value: *mut libc::c_void,
-    ) -> libc::c_int;
-
-    pub fn GC_pthread_join(native: libc::pthread_t, value: *mut *mut libc::c_void) -> libc::c_int;
-
-    pub fn GC_pthread_exit(value: *mut libc::c_void) -> !;
-
-    pub fn GC_pthread_detach(thread: libc::pthread_t) -> libc::c_int;
-
-    pub fn GC_init();
-
-    pub fn GC_keep_alive(ptr: *mut u8);
-
-    pub fn GC_set_finalize_on_demand(state: i32);
-
-    pub fn GC_set_finalizer_notifier(f: extern "C" fn());
-
-    pub fn GC_should_invoke_finalizers() -> u32;
-
-    pub fn GC_invoke_finalizers() -> u64;
-
-    pub fn GC_get_gc_no() -> u64;
-
-    pub fn GC_enable();
-
-    pub fn GC_is_disabled() -> i32;
-
-    pub fn GC_disable();
 }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -85,8 +85,12 @@ impl Thread {
             };
         }
 
-        let ret =
-            crate::bdwgc::GC_pthread_create(&mut native, attr.as_ptr(), thread_start, p as *mut _);
+        let ret = crate::bdwgc::GC_pthread_create(
+            &mut native,
+            attr.as_ptr() as *const bdwgc::pthread_attr_t,
+            Some(thread_start),
+            p as *mut _,
+        );
         // Note: if the thread creation fails and this assert fails, then p will
         // be leaked. However, an alternative design could cause double-free
         // which is clearly worse.

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -20,7 +20,7 @@ use serde_derive::Deserialize;
 use tracing::{instrument, span};
 
 use crate::core::build_steps::gcc::{Gcc, add_cg_gcc_cargo_flags};
-use crate::core::build_steps::tool::SourceType;
+use crate::core::build_steps::tool::{Bindgen, SourceType};
 use crate::core::build_steps::{dist, llvm};
 use crate::core::builder;
 use crate::core::builder::{
@@ -291,6 +291,9 @@ impl Step for Std {
         for rustflag in self.extra_rust_args.iter() {
             cargo.rustflag(rustflag);
         }
+
+        let bindgen = builder.ensure(Bindgen { compiler, target });
+        cargo.env("RUSTC_BINDGEN", bindgen.tool_path);
 
         let _guard = builder.msg(
             Kind::Build,

--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -16,6 +16,7 @@ pub fn filter_dirs(path: &Path) -> bool {
         "library/backtrace",
         "library/portable-simd",
         "library/stdarch",
+        "src/tools/bindgen",
         "src/tools/cargo",
         "src/tools/clippy",
         "src/tools/libcxx-version",


### PR DESCRIPTION
As part of the bootstrap phase, we now search for
`src/bdwgc/include/gc.h` and use that to automatically generate Rust
bindings. This is less error-prone and means that we can any BDWGC API
we wish without having to manually export them one by one.