### PR TITLE
Remove git --unshallow from CI script

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -6,15 +6,15 @@ YKSOMV=4d3679fca1139876adccdbd9a27f110b91b229fa
 GRMTOOLSV=7fff436c3659f103eac658e68808990410d2594b
 set -e
 
-# This is needed because Alloy is rebased on top of rustc, and we need enough
-# depth for the bootstrapper to find the correct llvm sha
-git fetch --unshallow
-
 export CARGO_HOME="$(pwd)/.cargo"
 export RUSTUP_HOME="$(pwd)/.rustup"
 
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 18)) # 18 GiB
+
+if $(git rev-parse --is-shallow-repository); then
+    git fetch --unshallow
+fi
 
 /usr/bin/time -v python3 x.py test --stage 2 --config .buildbot.config.toml --exclude rustdoc-json --exclude debuginfo
 


### PR DESCRIPTION
This is a holdover from when we used to always require building LLVM from source. We should get rid of it because it makes assumptions about how the CI repo was cloned (which is not always the same when used on b13 and TryCI).